### PR TITLE
Fixes or_idemp

### DIFF
--- a/regex.v
+++ b/regex.v
@@ -253,7 +253,6 @@ induction xs.
   rewrite (compare_equal r1 r2 p).
   apply IHxs.
   apply compare_reflex.
-  exact a.
 Qed.
 
 Theorem or_id : forall (xs: list X) (r: regex),


### PR DESCRIPTION
`or_idemp` doesn't compile for me with the `exact a`.