### PR TITLE
Adds a GitHub action to check proof with Coq on each push

### DIFF
--- a/.github/workflows/check_proofs.yml
+++ b/.github/workflows/check_proofs.yml
@@ -1,0 +1,44 @@
+name: Check Proofs
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: set environment variables
+      run: |
+        echo "::set-env name=CACHE_BIN::$GITHUB_WORKSPACE/.cache/bin"
+        echo "::set-env name=PATH::$GITHUB_WORKSPACE/.cache/bin:$PATH"
+        echo "::set-env name=OPAMROOT::$GITHUB_WORKSPACE/.cache/.opam"
+    - name: Cache Opam
+      id: cache-opam
+      uses: actions/cache@v1
+      with:
+        path: .cache
+        key: opam-coq-8-11
+    - name: install opam
+      if: steps.cache-opam.outputs.cache-hit != 'true'
+      run: |
+        mkdir -p $CACHE_BIN
+        cd $CACHE_BIN
+        wget https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux
+        mv opam-2.0.6-x86_64-linux opam
+        chmod +x opam
+    - name: Install coq
+      if: steps.cache-opam.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get install bubblewrap
+        opam init -c 4.07.1
+        eval $(opam env)
+        opam repo add coq-released https://coq.inria.fr/opam/released
+        opam install coq -y
+        coqc --version
+    - name: Check proofs with Coq
+      run: |
+        eval $(opam env)
+        coqc --version
+        cd $GITHUB_WORKSPACE
+        coqc regex.v -verbose

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Check Proofs](https://github.com/awalterschulze/regex-reexamined-coq/workflows/Check%20Proofs/badge.svg)
+
 # Regular-expression derivatives reexamined with Coq
 
 [Regular-expression derivatives reexamined](https://www.ccs.neu.edu/home/turon/re-deriv.pdf) is a paper by Scott Owens, John Reppy and Aaron Turon.


### PR DESCRIPTION
A badge in the README shows the latest build status of the master branch.

The check_proofs action first installs opam and Coq. It then compiles regex.v
with coqc.

The opam root (including the Coq installation) is cached for future runs. The
first run takes about 16mins and subsequent runs using the cache take 30s.

This is a first attempt. An obvious improvement is to use Coq's utility for
autogenerating a Makefile instead of hardcoding the files to check.