### PR TITLE
Walters attempt at reorder

### DIFF
--- a/reorder.v
+++ b/reorder.v
@@ -383,22 +383,15 @@ Lemma eval_list_concatenation'
   : forall (xs ys : list X)
   , eval_list (xs ++ ys) = Op (eval_list xs) (eval_list ys).
 Proof.
-induction xs, ys.
+induction xs.
 - simpl.
+  intros ys.
+  rewrite proof_comm.
   rewrite proof_id.
   reflexivity.
 - simpl.
-  rewrite proof_comm with (x := Identity).
-  rewrite proof_id.
-  reflexivity.
-- simpl.
+  intros.
   rewrite IHxs.
-  simpl.
-  rewrite proof_assoc.
-  reflexivity.
-- simpl.
-  rewrite IHxs.
-  simpl.
   rewrite proof_assoc.
   reflexivity.
 Qed.
@@ -421,40 +414,49 @@ induction xs.
   reflexivity.
 Qed.
 
-Lemma to_tree_step
-  : forall (xs : list X) (a: X)
-  , to_tree (a :: xs) = bin (value a) (to_tree xs).
-Proof.
-  simpl.
-Qed.
-
 (* to_list_to_tree' is a helper lemma for eval_tree_sort_is_correct' *)
 Lemma to_list_to_tree'
   : forall (xs : list X)
   , eval_list (to_list (to_tree xs)) = eval_list xs.
 Proof.
 induction xs.
-- simpl.
-  rewrite proof_id.
-  reflexivity.
-- simpl.
-  induction xs.
-  + simpl; rewrite proof_id; reflexivity.
-  + rewrite <- IHxs.
-    induction xs.
-    * simpl. repeat rewrite proof_id. reflexivity.
-    *  
-induction xs.
-  + simpl; rewrite proof_id; reflexivity.
-  + simpl.
-     
-    
-  
-  
-
-  
-  
-Admitted.
+- simpl. rewrite proof_id. reflexivity.
+- induction xs.
+  + simpl. rewrite proof_id. reflexivity.
+  + (* We are two levels into induction:
+    `eval_list (to_list (to_tree (a :: a0 :: xs))) = eval_list (a :: a0 :: xs)`
+    We want to pull `a` to the front of the expression and get:
+    `Op a (eval_list (to_list (to_tree (a0 :: xs))))`
+    So we can use our induction hypothesis:
+    `eval_list (to_list (to_tree (a0 :: xs))) = eval_list (a0 :: xs)`
+    To do this, we want to restrict the unfolding of to_tree to only unfold when it can resolve a match.
+    We use: `Arguments to_tree: simpl nomatch.` to do this, see the docs here:
+    https://coq.inria.fr/distrib/current/refman/proof-engine/tactics.html?highlight=simpl%20nomatch#coq:tacn.simpl
+    *)
+    Arguments to_tree: simpl nomatch.
+    simpl to_tree.
+    (* We have now moved `a` out of to_tree:
+    `eval_list (to_list (bin (value a) (to_tree (a0 :: xs)))) = eval_list (a :: a0 :: xs)`
+    Now we want to move `a` out of to_list.
+    To do this we use the same trick to restrict the simplification of to_list.
+    *)
+    Arguments to_list: simpl nomatch.
+    simpl to_list.
+    (* We have now moved `a` out of to_list:
+    `eval_list (a :: to_list (to_tree (a0 :: xs))) = eval_list (a :: a0 :: xs)`
+    Now we want to move the `a` out of eval_list.
+    To do this we use the same trick again to limit the reductions applied to eval_list.
+    *)
+    Arguments eval_list: simpl nomatch.
+    simpl eval_list.
+    (* We have moved `a` all the way out of the eval_list expression:
+    `Op a (eval_list (to_list (to_tree (a0 :: xs)))) = Op a (Op a0 (eval_list xs))`
+    Now we can apply our hypothesis.
+    *)
+    rewrite IHxs.
+    simpl.
+    reflexivity.
+Qed.
 
 (* eval_tree_sort_is_correct' shows that
    eval_tree_sort is equivalent to eval_tree
@@ -463,6 +465,36 @@ Theorem eval_tree_sort_is_correct'
     : forall (xs: tree X)
     , eval_tree xs = eval_tree_sort xs.
 Proof.
-Admitted.
+intros.
+unfold eval_tree_sort.
+(* 
+We have to prove:
+`eval_tree xs = eval_tree (to_tree (sort (to_list xs)))`
+We can rewrite eval_tree to get to eval_list:
+`eval_tree xs = eval_list (to_list xs)`
+*)
+rewrite eval_tree_factorizes_through_eval_list'.
+rewrite eval_tree_factorizes_through_eval_list'.
+(*
+Now we can forget about eval_tree and focus on eval_list.
+`eval_list (to_list xs) = eval_list (to_list (to_tree (sort (to_list xs))))`
+We know that `to_list . to_tree = id`:
+`eval_list (to_list (to_tree xs)) = eval_list xs.`
+*)
+rewrite to_list_to_tree'.
+(*
+So we can remove `to_list (to_tree` from the equation:
+`eval_list (to_list xs) = eval_list (sort (to_list xs))`
+We have already proven that evaluation is not effected by sorting:
+`eval_list xs = eval_list_sort xs`
+*)
+rewrite eval_list_sort_is_correct.
+(*
+And from definition we know that:
+`eval_list_sort = eval_list . sort`
+*)
+unfold eval_list_sort.
+reflexivity.
+Qed.
 
 End Reorder.


### PR DESCRIPTION
I needed to do these proofs for myself as well, so I could learn from others.

Looking at the proofs done by @Nielius and @paulcadman was super helpful.
I couldn't have done it without your work.
The key for me was how @Nielius broke it up into Lemmas and @paulcadman broke `to_list_to_tree` up into even more into Lemmas.
Another thing was that the current to_tree function and even this "better" one, makes the proving harder than it should be.  This results in multiple levels of induction, where only one or two should be enough, but I guess it was good practice.

I have also added comments to explain my reasoning.

I am kind of wondering how @Nielius decided when to break something up into separate Lemmas, because this does not come naturally to me at all.

I think I figured out @paulcadman broke things up, to make sure that `simpl` only took on step.
I bypassed this with `Arguments <function name>: simpl nomatch.`, but I think @paulcadman 's is still more readable, since I needed comments to make mine clear.