### PR TITLE
Moves derive and match definitions to a new module.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ build:
 	coqc compare_regex.v
 	coqc reduce_orb.v
 
+	coqc derive_def.v
+	coqc setoid.v
 	coqc derive.v
 	coqc smart_or.v
 	coqc smart.v

--- a/derive_def.v
+++ b/derive_def.v
@@ -1,0 +1,93 @@
+Set Implicit Arguments.
+Set Asymmetric Patterns.
+
+Require Import List.
+Require Import Bool.
+
+Require Import comparable.
+Require Import nullable.
+Require Import regex.
+
+Definition is_eq {X: Set} {tc: comparable X} (x y: X) : bool :=
+  match compare x y with
+  | Eq => true
+  | _ => false
+  end.
+
+(* derive returns the regular expression that is left to match
+   after matching the input character x, for example:
+   derive (ba)*      b    = a(ba)*
+   derive a          a    = empty
+   derive b          a    = nothing
+   derive ab|a       a    = b|empty
+   derive bc         b    = c
+   derive (a|empty)b a    = b
+   derive (a|empty)b b    = empty
+   derive empty b    b    = empty
+*)
+Fixpoint derive {X: Set} {tc: comparable X} (r: regex X) (x: X) : regex X :=
+  match r with
+  | nothing => nothing _
+  | empty => nothing _
+  | char y => if is_eq x y
+    then empty _
+    else nothing _
+  | or s t => or (derive s x) (derive t x)
+  | and s t => and (derive s x) (derive t x)
+  | concat s t =>
+    if nullable s
+    then or (concat (derive s x) t) (derive t x)
+    else concat (derive s x) t
+  | not s => not (derive s x)
+  | zero_or_more s => concat (derive s x) (zero_or_more s)
+  end.
+
+Definition matches {X: Set} {tc: comparable X} (r: regex X) (xs: list X) : bool :=
+  nullable (fold_left derive xs r).
+
+(* fold_matches tries to find a expression
+   `nullable (fold_left derive XS R)`
+   in the goal, where XS and R are variables.
+   It then applies the fold tactic to
+   refold:
+   `nullable (fold_left derive XS R)`
+   into:
+   `matches XS R`
+   since that is the definition of matches.
+*)
+Ltac fold_matches :=
+  match goal with
+    | [ |- context [nullable (fold_left derive ?XS ?R)] ] =>
+      fold (matches R XS)
+  end.
+
+(*
+simpl_matches simplifies the current expression
+with the cbn tactic and tries to fold back up any
+matches expressions it can spot.
+*)
+Ltac simpl_matches :=
+  cbn; repeat fold_matches.
+
+Theorem or_is_logical_or: forall {X: Set} {tc: comparable X} (xs: list X) (r s: regex X),
+  matches (or r s) xs = (orb (matches r xs) (matches s xs)).
+Proof.
+  induction xs; intros; simpl_matches.
+  - trivial.
+  - apply IHxs.
+Qed.
+
+Theorem and_is_logical_and: forall {X: Set} {tc: comparable X} (xs: list X) (r s: regex X),
+  matches (and r s) xs = (andb (matches r xs) (matches s xs)).
+Proof.
+(* TODO: Good First Issue *)
+Admitted.
+
+(* not(not(r)) = r *)
+Theorem not_is_logical_not : forall {X: Set} {tc: comparable X} (xs: list X) (r: regex X),
+  matches (not r) xs = negb (matches r xs).
+Proof.
+  induction xs; intros; simpl_matches.
+  - reflexivity.
+  - apply IHxs.
+Qed.

--- a/setoid.v
+++ b/setoid.v
@@ -1,10 +1,10 @@
 Set Implicit Arguments.
 
-Require Export Relations.
+Require Export Relation_Definitions.
 Require Export Setoid.
 
 Require Import comparable.
-Require Import derive.
+Require Import derive_def.
 Require Import nullable.
 Require Import orb_simple.
 Require Import regex.
@@ -165,6 +165,15 @@ Section RegexEq.
   Add Parametric Morphism: (@zero_or_more X)
       with signature regex_eq ==> regex_eq as zero_or_more_morph.
   Proof.
-    Admitted.
+  Admitted.
 
 End RegexEq.
+
+Existing Instance regex_setoid.
+Existing Instance and_morph_Proper.
+Existing Instance or_morph_Proper.
+Existing Instance not_morph_Proper.
+Existing Instance concat_morph_Proper.
+Existing Instance nullable_morph_Proper.
+Existing Instance derive_morph_Proper.
+


### PR DESCRIPTION
The new module in derive_def.v can then be imported by both setoid.v and derive.v

Also adds `Existing Instance` for `regex_setoid` and associated morphisms so
they can be used in modules that import setoid. (By default instances inside a
Section are not exported).

@awalterschulze This is what you had in mind in https://github.com/awalterschulze/regex-reexamined-coq/pull/42

I couldn't figure out how to make the `setoid` instance and morphisms visible in modules that import `setoid`. I eventually worked out `Existing Instance` does the trick.