### PR TITLE
matches predicate: added and, but not not and also the theorem to tie it all together matches_prop_describes_matches_impl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ build:
 	coqc compare_regex.v
 	coqc reduce_orb.v
 
-	coqc matches_pred.v
 	coqc derive_def.v
+	coqc matches_pred.v
 	coqc setoid.v
 	coqc derive.v
 	coqc smart_or.v

--- a/matches_pred.v
+++ b/matches_pred.v
@@ -2,7 +2,7 @@ Require Import List.
 Import ListNotations.
 
 Require Import comparable.
-Require Import derive.
+Require Import derive_def.
 Require Import regex.
 
 Reserved Notation "xs =~ r" (at level 80).

--- a/matches_pred.v
+++ b/matches_pred.v
@@ -13,12 +13,6 @@ Inductive matches {A: Type} {C: comparable A} : regex A -> (list A) ->  Prop :=
   | char_matches (a : A):
     [a] =~ char a
 
-  | concat_matches (r s : regex A) (xs ys: list A) :
-    xs =~ r ->
-    ys =~ s ->
-    (* --------- *)
-    (xs ++ ys) =~ concat r s
-
   | or_matches_l (r s : regex A) (xs : list A):
     xs =~ r ->
     (* --------- *)
@@ -28,6 +22,22 @@ Inductive matches {A: Type} {C: comparable A} : regex A -> (list A) ->  Prop :=
     xs =~ s ->
     (* --------- *)
     xs =~ or r s
+
+  | and_matches (r s : regex A) (xs: list A) :
+    xs =~ r ->
+    xs =~ s ->
+    (* --------- *)
+    xs =~ and r s
+
+  | concat_matches (r s : regex A) (xs ys: list A) :
+    xs =~ r ->
+    ys =~ s ->
+    (* --------- *)
+    (xs ++ ys) =~ concat r s
+
+  (* | not_matches (r : regex A) (xs : list A):
+    TODO: Help Wanted
+  *)
 
   | star_matches_nil (r : regex A):
     [] =~ star r

--- a/matches_pred.v
+++ b/matches_pred.v
@@ -64,4 +64,4 @@ Theorem matches_prop_describes_matches_impl:
    then matches_prop can be used in proofs,
    rather than induction on xs and matchesb.
 *)
-Admitted.
+Abort.

--- a/matches_pred.v
+++ b/matches_pred.v
@@ -2,11 +2,12 @@ Require Import List.
 Import ListNotations.
 
 Require Import comparable.
+Require Import derive.
 Require Import regex.
 
 Reserved Notation "xs =~ r" (at level 80).
 
-Inductive matches {A: Type} {C: comparable A} : regex A -> (list A) ->  Prop :=
+Inductive matches_prop {A: Type} {C: comparable A} : regex A -> (list A) ->  Prop :=
   | empty_matches :
     [] =~ empty
 
@@ -48,4 +49,19 @@ Inductive matches {A: Type} {C: comparable A} : regex A -> (list A) ->  Prop :=
     (* --------- *)
     (xs ++ ys) =~ star r
 
-  where "xs =~ r" := (matches r xs).
+  where "xs =~ r" := (matches_prop r xs).
+
+Theorem matches_prop_describes_matches_impl: 
+  forall
+    {A: Type}
+    {cmp: comparable A}
+    (r: regex A) 
+    (xs: list A), 
+  matchesb r xs = true <-> matches_prop r xs
+.
+(* TODO: Help Wanted 
+   If this theorem is proved,
+   then matches_prop can be used in proofs,
+   rather than induction on xs and matchesb.
+*)
+Admitted.


### PR DESCRIPTION
I also reorderd the constructors to match the order of the regex constructors.

I have tried
```
| not_matches (r : regex A) (xs : list A):
    ((xs =~ r) -> False) ->
    (* --------- *)
    xs =~ r
```

But then we run into

```
Error: Non strictly positive occurrence of "matches" in
 "forall (r : regex A) (xs : list A),
  (matches A C r xs -> False) -> matches A C r xs".
```