### PR TITLE
flesh out sort.v

### DIFF
--- a/src/comparable.v
+++ b/src/comparable.v
@@ -221,3 +221,18 @@ Fixpoint comparable_list {A: Type} {cmp: comparable A} (xs: list A) (ys: list A)
           end
       end
   end.
+
+
+Definition compare_leq {A: Type} {cmp: comparable A} (x y: A) : Prop :=
+  (compare x y = Eq) \/ (compare x y = Lt).
+
+Lemma compare_leq_trans {A: Type} {cmp: comparable A} (x y z: A) :
+  (compare_leq x y) -> (compare_leq y z) -> (compare_leq x z).
+Proof.
+  intros.
+  unfold compare_leq in *.
+  Hint Resolve 
+  match goal with
+  | P: context [compare ?x ?y] |- _ => destruct (compare x y)
+  end; auto.
+

--- a/src/comparable.v
+++ b/src/comparable.v
@@ -18,12 +18,12 @@ Class comparable (A : Type) :=
              (p: compare x y = Eq)
              (q: compare y z = Eq)
     , compare x z = Eq
-  ; proof_compare_lt_assoc
+  ; proof_compare_lt_trans
     : forall (x y z: A)
              (p: compare x y = Lt)
              (q: compare y z = Lt)
     , compare x z = Lt
-  ; proof_compare_gt_assoc
+  ; proof_compare_gt_trans
     : forall (x y z: A)
              (p: compare x y = Gt)
              (q: compare y z = Gt)
@@ -109,12 +109,12 @@ induction_on_compare.
 - reflexivity.
 - symmetry in Heqc.
   symmetry in p.
-  remember (proof_compare_lt_assoc x1 x2 x1 Heqc p).
+  remember (proof_compare_lt_trans x1 x2 x1 Heqc p).
   rewrite <- e.
   apply proof_compare_eq_reflex.
 - symmetry in Heqc.
   symmetry in p.
-  remember (proof_compare_gt_assoc x1 x2 x1 Heqc p).
+  remember (proof_compare_gt_trans x1 x2 x1 Heqc p).
   rewrite <- e.
   apply proof_compare_eq_reflex.
 Qed.
@@ -128,7 +128,7 @@ Theorem compare_lt_not_symm_1
   , False.
 Proof.
 intros.
-assert (p1 := proof_compare_lt_assoc x1 x2 x1 c12 c21).
+assert (p1 := proof_compare_lt_trans x1 x2 x1 c12 c21).
 assert (p2 := proof_compare_eq_reflex x1).
 rewrite p1 in p2.
 discriminate.
@@ -181,7 +181,7 @@ induction iH.
   rewrite HeqiH in p.
   discriminate.
 - symmetry in HeqiH.
-  assert (a := proof_compare_lt_assoc x1 x2 x1 p HeqiH).
+  assert (a := proof_compare_lt_trans x1 x2 x1 p HeqiH).
   rewrite proof_compare_eq_reflex in a.
   discriminate.
 - reflexivity.
@@ -201,7 +201,7 @@ Proof.
     discriminate.
   - trivial.
   - symmetry in Heqc.
-    set (a := proof_compare_gt_assoc x1 x2 x1 p Heqc).
+    set (a := proof_compare_gt_trans x1 x2 x1 p Heqc).
     rewrite proof_compare_eq_reflex in a.
     discriminate.
 Qed.

--- a/src/compare_nat.v
+++ b/src/compare_nat.v
@@ -44,7 +44,7 @@ Proof.
 (* TODO *)
 Admitted.
 
-Lemma nat_proof_compare_lt_assoc
+Lemma nat_proof_compare_lt_trans
   : forall (x y z: nat)
            (p: nat_compare x y = Lt)
            (q: nat_compare y z = Lt)
@@ -53,7 +53,7 @@ Proof.
 (* TODO *)
 Admitted.
 
-Lemma nat_proof_compare_gt_assoc
+Lemma nat_proof_compare_gt_trans
   : forall (x y z: nat)
            (p: nat_compare x y = Gt)
            (q: nat_compare y z = Gt)
@@ -67,8 +67,8 @@ Instance comparable_nat : comparable nat :=
   ; proof_compare_eq_is_equal := nat_proof_compare_eq_is_equal
   ; proof_compare_eq_reflex := nat_proof_compare_eq_reflex
   ; proof_compare_eq_trans := nat_proof_compare_eq_trans
-  ; proof_compare_lt_assoc := nat_proof_compare_lt_assoc
-  ; proof_compare_gt_assoc := nat_proof_compare_gt_assoc
+  ; proof_compare_lt_trans := nat_proof_compare_lt_trans
+  ; proof_compare_gt_trans := nat_proof_compare_gt_trans
   }.
 
 (* test_compare_list simply tests whether nat can be used

--- a/src/compare_regex.v
+++ b/src/compare_regex.v
@@ -106,7 +106,7 @@ Proof.
 (* TODO: Good First Issue *)
 Admitted.
 
-Lemma regex_proof_compare_lt_assoc
+Lemma regex_proof_compare_lt_trans
     : forall {A: Type}
              {cmp: comparable A}
              (x y z: regex A)
@@ -117,7 +117,7 @@ Proof.
 (* TODO: Good First Issue *)
 Admitted.
 
-Lemma regex_proof_compare_gt_assoc
+Lemma regex_proof_compare_gt_trans
     : forall {A: Type}
              {cmp: comparable A}
              (x y z: regex A)
@@ -133,8 +133,8 @@ Instance comparable_regex {A: Type} {cmp: comparable A} : comparable (regex A) :
   ; proof_compare_eq_is_equal := regex_proof_compare_eq_is_equal
   ; proof_compare_eq_reflex := regex_proof_compare_eq_reflex
   ; proof_compare_eq_trans := regex_proof_compare_eq_trans
-  ; proof_compare_lt_assoc := regex_proof_compare_lt_assoc
-  ; proof_compare_gt_assoc := regex_proof_compare_gt_assoc
+  ; proof_compare_lt_trans := regex_proof_compare_lt_trans
+  ; proof_compare_gt_trans := regex_proof_compare_gt_trans
   }.
 
 Theorem compare_regex_is_compare: forall

--- a/src/simple.v
+++ b/src/simple.v
@@ -37,9 +37,6 @@ induction r, s; simpl; try easy.
     simpl in Heqc.
     rewrite <- Heqc.
     firstorder.
-    (* Locate "<>". *)
-    unfold Logic.not.
-    discriminate.
   + simpl.
     firstorder.
     unfold Logic.not.

--- a/src/simplified.v
+++ b/src/simplified.v
@@ -74,7 +74,7 @@ intros x1 x2 x3 x4.
 intros p12 p23 p34.
 simpl.
 firstorder.
-assert (p := proof_compare_lt_assoc x2 x3 x2 p23 H7).
+assert (p := proof_compare_lt_trans x2 x3 x2 p23 H7).
 rewrite proof_compare_eq_reflex in p.
 discriminate.
 Qed.

--- a/src/sort.v
+++ b/src/sort.v
@@ -9,7 +9,7 @@ Require Import Lia.
 Require Import comparable.
 
 (* is_sorted is a property that says whether a list is sorted *)
-Inductive is_sorted {A: Type} {tc: comparable A} : list A -> Prop :=
+Inductive is_sorted {A: Type} {cmp: comparable A} : list A -> Prop :=
   | empty_sorted : is_sorted nil
   | singleton_sorted (x: A) : is_sorted (x :: nil)
   | tail_sorted
@@ -22,7 +22,7 @@ Inductive is_sorted {A: Type} {tc: comparable A} : list A -> Prop :=
 .
 
 (* This is not really a bool... should it be? *)
-Fixpoint is_sortedb {A: Type} {tc: comparable A} (xs: list A) : Prop :=
+Fixpoint is_sortedb {A: Type} {cmp: comparable A} (xs: list A) : Prop :=
   match xs with
   | nil => True
   | (x'::xs') => match xs' with
@@ -37,7 +37,7 @@ Fixpoint is_sortedb {A: Type} {tc: comparable A} (xs: list A) : Prop :=
 
 Lemma is_sortedb_induction_step
   {A: Type}
-  {tc: comparable A}
+  {cmp: comparable A}
   (x x' : A)
   (xs: list A):
   ((compare x x' = Lt) \/ (compare x x' = Eq)) ->
@@ -49,7 +49,7 @@ Proof.
   destruct H; rewrite H; trivial.
 Qed.
 
-Inductive is_sorted'' {A: Type} {tc: comparable A} : list A -> Prop :=
+Inductive is_sorted'' {A: Type} {cmp: comparable A} : list A -> Prop :=
   | empty_sorted'' : is_sorted'' nil
   | singleton_sorted'' : forall x, is_sorted'' (x :: nil)
   | lessthan_sorted''
@@ -71,7 +71,7 @@ Inductive is_sorted'' {A: Type} {tc: comparable A} : list A -> Prop :=
 
 Lemma tail_of_is_sorted_is_sorted:
   forall {A: Type}
-  {tc: comparable A}
+  {cmp: comparable A}
   (x: A)
   (xs: list A),
   is_sorted (x :: xs) -> is_sorted xs.
@@ -82,7 +82,7 @@ Qed.
 
 Lemma first_two_of_is_sorted_are_sorted:
   forall {A: Type}
-  {tc: comparable A}
+  {cmp: comparable A}
   (x y: A)
   (xs: list A),
   is_sorted (x :: y :: xs) -> compare_leq x y.
@@ -96,7 +96,7 @@ Qed.
 
 Lemma tail_of_is_sortedb_is_sortedb:
   forall {A: Type}
-  {tc: comparable A}
+  {cmp: comparable A}
   (x: A)
   (xs: list A),
   is_sortedb (x :: xs) -> is_sortedb xs.
@@ -106,7 +106,7 @@ Abort.
 
 Lemma tail_of_is_sorted''_is_sorted'':
   forall {A: Type}
-  {tc: comparable A}
+  {cmp: comparable A}
   (x: A)
   (xs: list A),
   is_sorted'' (x :: xs) -> is_sorted'' xs.
@@ -114,7 +114,7 @@ Proof.
 (* TODO: Good First Issue *)
 Abort.
 
-Lemma list_inductive_equality: forall {A: Type} {tc: comparable A} (x y: A) (xs ys: list A),
+Lemma list_inductive_equality: forall {A: Type} {cmp: comparable A} (x y: A) (xs ys: list A),
     ( (x::xs) = (y::ys)) <-> (x = y /\ (xs = ys)).
 Proof.
   intros. split.
@@ -146,7 +146,7 @@ Local Ltac destruct_list_equality :=
 
 Section certified_decision_procedure.
   Context {A: Type}.
-  Context {tc: comparable A}.
+  Context {cmp: comparable A}.
 
   (* This is a certified decision procedure (as in Ch. 15 in [CPDT]). It is
    essentially the same as our definition of is_sortedb, except that instead of
@@ -215,7 +215,7 @@ End certified_decision_procedure.
 
 Section lemmas.
   Context {A: Type}.
-  Context {tc: comparable A}.
+  Context {cmp: comparable A}.
 
   Lemma is_sortedb_reverse_direction (x y : A) (xs : list A):
     is_sortedb (x::y::xs) ->
@@ -233,7 +233,7 @@ Section lemmas.
   Qed.
 End lemmas.
 
-Theorem is_sorted_and_is_sortedb_are_equivalent : forall {A: Type} {tc: comparable A} (xs: list A),
+Theorem is_sorted_and_is_sortedb_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),
   is_sorted xs <-> is_sortedb xs.
 Proof.
 Hint Unfold is_sortedb. (* TODO: deprecated *)
@@ -257,7 +257,7 @@ split.
       constructor; auto.
 Qed.
 
-Theorem is_sortedb_and_is_sorted''_are_equivalent : forall {A: Type} {tc: comparable A} (xs: list A),
+Theorem is_sortedb_and_is_sorted''_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),
   is_sortedb xs <-> is_sorted'' xs.
 Proof.
 (* TODO: Good First Issue *)
@@ -265,7 +265,7 @@ Abort.
 
 Section indices.
   Context {A: Type}.
-  Context {tc: comparable A}.
+  Context {cmp: comparable A}.
 
   Lemma get_recursion_helper (n : nat) (x : A) (xs : list A):
     (S n < length (x :: xs)) <-> (n < length xs).
@@ -645,7 +645,7 @@ Section indices.
 End indices.
 
 (* insert_sort is a helper function for sort *)
-Fixpoint insert_sort {A: Type} {tc: comparable A} (xs: list A) (x: A) : list A :=
+Fixpoint insert_sort {A: Type} {cmp: comparable A} (xs: list A) (x: A) : list A :=
   match xs with
   | nil => x :: nil
   | (x'::xs') => match compare x x' with
@@ -656,20 +656,20 @@ Fixpoint insert_sort {A: Type} {tc: comparable A} (xs: list A) (x: A) : list A :
   end.
 
 (* insert_sort_sorts is a helper lemma for sort_sorts *)
-Lemma insert_sort_sorts: forall {A: Type} {tc: comparable A} (xs: list A) (x: A) {s: is_sorted xs},
+Lemma insert_sort_sorts: forall {A: Type} {cmp: comparable A} (xs: list A) (x: A) {s: is_sorted xs},
   is_sorted (insert_sort xs x).
 Proof.
 (* TODO: Good First Issue *)
 Abort.
 
 (* sort is a helper function for eval_list_sort *)
-Fixpoint sort {A: Type} {tc: comparable A} (xs: list A) : list A :=
+Fixpoint sort {A: Type} {cmp: comparable A} (xs: list A) : list A :=
   match xs with
   | nil => nil
   | (x'::xs') => insert_sort (sort xs') x'
   end.
 
-Theorem sort_sorts: forall {A: Type} {tc: comparable A} (xs: list A),
+Theorem sort_sorts: forall {A: Type} {cmp: comparable A} (xs: list A),
   is_sorted (sort xs).
 Proof.
 Abort.

--- a/src/sort.v
+++ b/src/sort.v
@@ -339,6 +339,9 @@ Section indices.
         assumption.
   Defined.
 
+  (* Maybe it would have been better to just use nth_error together
+  with some tactics that prove that the bounds are correct. *)
+
   Lemma get_from_tail:
     forall (xs : list X) (x: X)
            (i : nat)

--- a/src/sort.v
+++ b/src/sort.v
@@ -238,15 +238,15 @@ End lemmas.
 Theorem is_sorted_and_is_sortedb_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),
   is_sorted xs <-> is_sortedb xs.
 Proof.
-Hint Unfold is_sortedb. (* TODO: deprecated *)
-Hint Resolve is_sortedb_induction_step.
+Hint Unfold is_sortedb: sorted_db. (* TODO: deprecated *)
+Hint Resolve is_sortedb_induction_step: sorted_db.
 
 split.
-- induction xs as [(*nil*)| x0 xs' IH]; auto.
+- induction xs as [(*nil*)| x0 xs' IH]; auto with sorted_db.
   intros.
   try (match goal with
        | [ H: is_sorted ?xs |- _] => inversion H
-       end); subst; auto.
+       end); subst; auto with sorted_db.
 
 - induction xs as [| x0 xs'].
   + intros.
@@ -256,7 +256,7 @@ split.
     * constructor.
     * set (Hsort := is_sortedb_reverse_direction _ _ _ H).
       destruct Hsort as [Hcomp Hsublist].
-      constructor; auto.
+      constructor; auto with sorted_db.
 Qed.
 
 Theorem is_sortedb_and_is_sorted''_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),

--- a/src/sort.v
+++ b/src/sort.v
@@ -15,7 +15,7 @@ Inductive is_sorted {A: Type} {cmp: comparable A} : list A -> Prop :=
   | tail_sorted
     (x: A)
     (y: A)
-    (c : compare x y = Lt \/ compare x y = Eq)
+    (c : compare_leq x y)
     (xs: list A)
     (s: is_sorted (y :: xs))
     : is_sorted (x :: y :: xs)
@@ -40,7 +40,7 @@ Lemma is_sortedb_induction_step
   {cmp: comparable A}
   (x x' : A)
   (xs: list A):
-  ((compare x x' = Lt) \/ (compare x x' = Eq)) ->
+  (compare_leq x x') ->
   (is_sortedb (x'::xs)) ->
   is_sortedb (x::x'::xs).
 Proof.
@@ -88,9 +88,7 @@ Lemma first_two_of_is_sorted_are_sorted:
   is_sorted (x :: y :: xs) -> compare_leq x y.
 Proof.
   intros.
-  unfold compare_leq.
   inversion H.
-  apply or_comm.
   assumption.
 Qed.
 
@@ -178,6 +176,8 @@ Section certified_decision_procedure.
         => assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
       end.
 
+    Hint Unfold compare_leq: sorted_db.
+
     (*
 The essence of the statement below is as simple as is_sortedb, but there are two
 complicating factors:
@@ -207,7 +207,7 @@ the match statements.
               end);
       try (subst; constructor; auto with sorted_db);
       try (intro; is_sorted_contradiction_via_tail).
-    - intro. inversion H; subst.
+    - intro H. inversion H; subst.
       + discriminate.
       + destruct c; subst; destruct_list_equality; subst; contradiction_from_compares.
   Defined.
@@ -219,14 +219,14 @@ Section lemmas.
 
   Lemma is_sortedb_reverse_direction (x y : A) (xs : list A):
     is_sortedb (x::y::xs) ->
-    (compare x y = Lt \/ compare x y = Eq) /\ (is_sortedb (y::xs)).
+    (compare_leq x y) /\ (is_sortedb (y::xs)).
   Proof.
     intros.
     unfold is_sortedb in H.
     split.
     - destruct (compare x y) eqn:Hcomp.
-      + apply or_intror. reflexivity.
-      + apply or_introl. reflexivity.
+      + apply or_introl. assumption.
+      + apply or_intror. assumption.
       + contradiction.
     - fold (is_sortedb (y::xs)) in H.
       destruct (compare x y); (assumption || contradiction).

--- a/src/sort.v
+++ b/src/sort.v
@@ -99,7 +99,9 @@ Lemma tail_of_is_sortedb_is_sortedb:
   (xs: list A),
   is_sortedb (x :: xs) -> is_sortedb xs.
 Proof.
-(* TODO: Good First Issue *)
+(* TODO: Good First Issue
+By Admitting this we previously let a bug slip through
+ *)
 Abort.
 
 Lemma tail_of_is_sorted''_is_sorted'':

--- a/src/sort.v
+++ b/src/sort.v
@@ -5,66 +5,66 @@ Require Import List.
 
 Require Import comparable.
 
+(* TODO:
+  - change Admitted to Abort
+  - rename X to A and tc to cmp
+  *)
+
 (* is_sorted is a property that says whether a list is sorted *)
-Fixpoint is_sorted {A: Type} {cmp: comparable A} (xs: list A) : Prop :=
+Inductive is_sorted {X: Set} {tc: comparable X} : list X -> Prop :=
+  | empty_sorted : is_sorted nil
+  | singleton_sorted (x: X) : is_sorted (x :: nil)
+  | tail_sorted
+    (x: X)
+    (y: X)
+    (c : compare x y = Lt \/ compare x y = Eq)
+    (xs: list X)
+    (s: is_sorted (y :: xs))
+    : is_sorted (x :: y :: xs)
+.
+
+(* This is not really a bool... *)
+Fixpoint is_sortedb {X: Set} {tc: comparable X} (xs: list X) : Prop :=
   match xs with
   | nil => True
   | (x'::xs') => match xs' with
     | nil => True
     | (x''::xs'') => match compare x' x'' with
-      | Eq => is_sorted xs'
-      | Lt => is_sorted xs'
+      | Eq => is_sortedb xs'
+      | Lt => is_sortedb xs'
       | Gt => False
       end
     end
   end.
 
-Lemma is_sorted_sufficient_cond
-  {A: Type}
-  {cmp: comparable A}
-  (x x' : A)
-  (xs: list A):
+Lemma is_sortedb_induction_step
+  {X: Set}
+  {tc: comparable X}
+  (x x' : X)
+  (xs: list X):
   ((compare x x' = Lt) \/ (compare x x' = Eq)) ->
-  (is_sorted (x'::xs)) ->
-  is_sorted (x::x'::xs).
+  (is_sortedb (x'::xs)) ->
+  is_sortedb (x::x'::xs).
 Proof.
-intros.
-unfold is_sorted.
-destruct H; rewrite H; trivial.
+  intros.
+  unfold is_sortedb.
+  destruct H; rewrite H; trivial.
 Qed.
 
-Inductive is_sorted' {A: Type} {cmp: comparable A} : list A -> Prop :=
-  | empty_sorted' : is_sorted' nil
-  | singleton_sorted' (x: A) : is_sorted' (x :: nil)
-  | lessthan_sorted'
-    (x: A)
-    (y: A)
-    (c : compare x y = Lt)
-    (xs: list A)
-    (s: is_sorted' (y :: xs))
-    : is_sorted' (x :: y :: xs)
-  | equal_sorted'
-    (x: A)
-    (y: A)
-    (c : compare x y = Eq)
-    (xs: list A)
-    (s: is_sorted' (y :: xs))
-    : is_sorted' (x :: y :: xs)
-.
 
-Inductive is_sorted'' {A: Type} {cmp: comparable A} : list A -> Prop :=
+Inductive is_sorted'' {X: Set} {tc: comparable X} : list X -> Prop :=
   | empty_sorted'' : is_sorted'' nil
   | singleton_sorted'' : forall x, is_sorted'' (x :: nil)
   | lessthan_sorted''
-    : forall (x: A) (xs: list A),
-      (exists (y: A) (ys: list A),
+    : forall (x: X) (xs: list X),
+      (exists (y: X) (ys: list X),
       xs = (y :: ys)
       /\ compare x y = Lt)
       /\ is_sorted'' xs
       -> is_sorted'' (x :: xs)
   | equal_sorted''
-    : forall (x: A) (xs: list A),
-      (exists (y: A) (ys: list A),
+    : forall (x: X) (xs: list X),
+      (exists (y: X) (ys: list X),
       xs = (y :: ys)
       /\ compare x y = Eq)
       /\ is_sorted'' xs
@@ -72,83 +72,396 @@ Inductive is_sorted'' {A: Type} {cmp: comparable A} : list A -> Prop :=
 .
 
 Lemma tail_of_is_sorted_is_sorted:
-  forall {A: Type}
-  {cmp: comparable A}
-  (x: A)
-  (xs: list A),
+  forall {X: Set}
+  {tc: comparable X}
+  (x: X)
+  (xs: list X),
   is_sorted (x :: xs) -> is_sorted xs.
 Proof.
-(* TODO: Good First Issue 
-   By Admitting this we previously let a bug slip through
-*)
-Admitted.
+  intros.
+  inversion H; subst; (constructor || assumption).
+Qed.
 
-Lemma tail_of_is_sorted'_is_sorted':
-  forall {A: Type}
-  {cmp: comparable A}
-  (x: A)
-  (xs: list A),
-  is_sorted' (x :: xs) -> is_sorted' xs.
+Lemma tail_of_is_sortedb_is_sortedb:
+  forall {X: Set}
+  {tc: comparable X}
+  (x: X)
+  (xs: list X),
+  is_sortedb (x :: xs) -> is_sortedb xs.
 Proof.
 (* TODO: Good First Issue *)
 Admitted.
 
 Lemma tail_of_is_sorted''_is_sorted'':
-  forall {A: Type}
-  {cmp: comparable A}
-  (x: A)
-  (xs: list A),
+  forall {X: Set}
+  {tc: comparable X}
+  (x: X)
+  (xs: list X),
   is_sorted'' (x :: xs) -> is_sorted'' xs.
 Proof.
 (* TODO: Good First Issue *)
 Admitted.
 
-Theorem is_sorted_and_is_sorted'_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),
-  is_sorted xs <-> is_sorted' xs.
+Lemma list_inductive_equality: forall {X: Set} {tc: comparable X} (x y: X) (xs ys: list X),
+    ( (x::xs) = (y::ys)) <-> (x = y /\ (xs = ys)).
 Proof.
-intros.
-split.
-- induction xs as [(*nil*)| x0 xs' IH].
-  + simpl.
-    intros.
-    exact empty_sorted'.
-  + induction xs' as [(*nil*)| x1 xs''].
-    * simpl.
-      intros.
-      exact (singleton_sorted' x0).
-    * intros.
-      assert (is_sorted (x1 :: xs'')).
-      -- apply tail_of_is_sorted_is_sorted with (x := x0) (xs := (x1 :: xs'')).
-         assumption.
-      -- apply IH in H0.
-         simpl in H.
-         destruct (compare x0 x1) eqn:c.
-         ++ refine (equal_sorted' _ _ _).
-            ** exact c.
-            ** exact H0.
-         ++ exact (lessthan_sorted' _ c H0).
-         ++ contradiction.
-- induction xs as [(*nil*)| x0 xs' IH].
-  + simpl.
-    intros.
-    trivial.
-  + intros.
-    inversion H.
-    * simpl. trivial.
-    * cbn. rewrite c.
-(* TODO: Good First Issue
-   Finish this Proof
-*)
-Abort.
+  intros. split.
+  - split.
+    + assert (x = (hd x (x :: xs))) as Heq.
+      trivial.
+      rewrite H in Heq.
+      unfold hd in Heq.
+      assumption.
+    + assert (xs = (tl (x::xs))) as Heq.
+      trivial.
+      rewrite H in Heq.
+      unfold tl in Heq.
+      assumption.
+  - intros.
+    destruct H. subst. trivial.
+Qed.
 
-Theorem is_sorted'_and_is_sorted''_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),
-  is_sorted' xs <-> is_sorted'' xs.
+
+(* I don't know if we can use the definition of is_sortedb in this way. *)
+
+(* This follows the ideas (and some of the notation) from Ch. 15 of CPDT *)
+Inductive partial (P: Prop) : Set :=
+| Proved : P -> partial P
+| Uncertain : partial P.
+
+Notation "[ P ]" := (partial P).
+
+(* comparison -> [is_sorted xs] *)
+
+Section reflection.
+  Context {X: Set}.
+  Context {tc: comparable X}.
+
+
+  (* This is a certified decision procedure (as in Ch. 15 in [CPDT]). It is essentially
+   the same as our definition of is_sortedb, except that instead of giving True or False
+   as the end result, the end result is a dependent type, which shows that it is correct. *)
+  Definition check_is_sorted: forall (xs: list X), [is_sorted xs].
+    Hint Constructors is_sorted. (* TODO: deprecated *)
+
+    (* The essence of the statement below is as simple as is_sortedb. The only thing that makes it look
+     more complicated is that we need to use the "convoy trick" (see [CPDT]) twice. *)
+    refine (fix F (xs : list X): [is_sorted xs] :=
+              match xs return [is_sorted xs] with
+              | nil => Proved _
+              | (x0::xs') =>
+                (match xs' as l return (xs' = l) -> [is_sorted (x0::xs')] with
+                  | nil => (fun _ => Proved _)
+                  | (x1::xs'') =>
+                    (fun l0 =>
+                    (let comp := (compare x0 x1) in
+                     (match comp as H return (compare x0 x1 = H) -> [is_sorted (x0::xs')] with
+                      | Gt => (fun _ => Uncertain _)
+                      | _ => (fun Hcomp =>
+                                if (F xs')
+                                then Proved _
+                                else Uncertain _)
+                      end) _))
+                  end) _
+              end); subst; constructor; auto.
+  Defined.
+End reflection.
+
+Section lemmas.
+  Context {X: Set}.
+  Context {tc: comparable X}.
+
+  Lemma is_sortedb_reverse_direction (x y : X) (xs : list X):
+    is_sortedb (x::y::xs) ->
+    (compare x y = Lt \/ compare x y = Eq) /\ (is_sortedb (y::xs)).
+  Proof.
+    intros.
+    unfold is_sortedb in H.
+    split.
+    - destruct (compare x y) eqn:Hcomp.
+      + apply or_intror. reflexivity.
+      + apply or_introl. reflexivity.
+      + contradiction.
+    - fold (is_sortedb (y::xs)) in H.
+      destruct (compare x y); (assumption || contradiction).
+  Qed.
+End lemmas.
+
+Theorem is_sorted_and_is_sortedb_are_equivalent : forall {X: Set} {tc: comparable X} (xs: list X),
+  is_sorted xs <-> is_sortedb xs.
+Proof.
+Hint Unfold is_sortedb. (* TODO: deprecated *)
+Hint Resolve is_sortedb_induction_step.
+
+split.
+- induction xs as [(*nil*)| x0 xs' IH]; auto.
+  intros.
+  try (match goal with
+       | [ H: is_sorted ?xs |- _] => inversion H
+       end); subst; auto.
+
+- induction xs as [| x0 xs'].
+  + intros.
+    constructor.
+  + intros.
+    destruct xs' eqn:?.
+    * constructor.
+    * set (Hsort := is_sortedb_reverse_direction _ _ _ H).
+      destruct Hsort as [Hcomp Hsublist].
+      constructor; auto.
+Qed.
+
+Theorem is_sortedb_and_is_sorted''_are_equivalent : forall {X: Set} {tc: comparable X} (xs: list X),
+  is_sortedb xs <-> is_sorted'' xs.
 Proof.
 (* TODO: Good First Issue *)
-Abort.
+Admitted.
+
+Print sig.
+Print sigT.
+
+Section indices.
+  Context {X: Set}.
+  Context {tc: comparable X}.
+
+  Print hd.
+  Print List.
+
+  Lemma get_recursion_helper (n : nat) (x : X) (xs : list X):
+    (S n < length (x :: xs)) <-> (n < length xs).
+  Proof.
+    intros. split; (apply Lt.lt_S_n || apply Lt.lt_n_S); auto.
+  Defined.
+
+  (* The two lemmas below are sometimes useful in functional contexts *)
+
+  (* What I want:
+
+      a map {k : nat | k < length xs} -> {k : nat | k < length xs}
+
+    but I somehow want to say that this is just the map
+
+      k => (S k)
+
+    but with additional proofs attached
+   *)
+
+  Definition get_recursion_helper_dec (n : nat) (x : X) (xs : list X):
+    (S n < length (x :: xs)) -> (n < length xs) :=
+    fun (H : S n < length (x :: xs)) => Lt.lt_S_n n (length xs) H.
+
+  Definition get_recursion_helper_inc (n : nat) (x : X) (xs : list X):
+    (n < length xs) -> (S n < length (x :: xs)) :=
+    fun (H : n < length (xs)) => Lt.lt_n_S n (length xs) H.
+
+  Print Lt.lt_n_S.
+
+  Lemma length_nil {Y: Set}:
+    (@length Y nil) = 0.
+  Proof.
+    auto.
+  Qed.
+
+  Local Ltac nat_smaller_than_length_nil :=
+        (* The below just derives a contradiction when there is a nat n with n < length nil *)
+        repeat (match goal with
+                | [ P : {n : nat | n < length nil } |- _] => destruct P
+                | [ P : _ < length nil |- _ ] => rewrite (length_nil) in P
+                | [ P : ?x < 0 |- _ ] => apply PeanoNat.Nat.nlt_0_r with (n := x)
+        end); assumption.
+
+  (* Definition get_recursion_helper_dec_exist {x : X} {xs : list X}: *)
+  (*   { n : nat | S n < length (x :: xs)} -> { n : nat | n < length xs }. *)
+  (* Proof. *)
+  (*   intro ipf. *)
+  (*   destruct ipf as [i pf]. *)
+  (*   apply get_recursion_helper in pf. *)
+  (*   exact (exist _ i pf). *)
+  (* Defined. *)
+
+  (* Print get_recursion_helper_dec_exist. *)
+
+  (* (* This just says that the map *) *)
+  (* Lemma get_recursion_helper_dec_proj (ipf : {n : nat | S n < length (x :: xs)}): *)
+  (*   proj1_sig ipf *)
+
+  (* apply get_recursion_helper. Qed. *)
+
+  Fixpoint get (xs: list X): { n: nat | n < (length xs)} -> X.
+    intros. destruct H as [n pf].
+
+    destruct xs as [| x0 xs'] eqn:?.
+    - (* xs cannot be empty *)
+      exfalso.
+      nat_smaller_than_length_nil.
+    - destruct n.
+      + (* if n = 0, return the first element *)
+        exact x0.
+      + (* otherwise, recurse *)
+        exact (get xs' (exist _ n (get_recursion_helper_dec pf))).
+  Defined.
+
+  (* Alternative definition, using std lib *)
+  Definition get' (xs: list X): { n: nat | n < (length xs)} -> X.
+    intro H. destruct H as [n pf].
+    destruct (nth_error xs n) eqn:?.
+    - exact x.
+    - exfalso.
+      (* This is basically an application of nth_error_nth', except that we
+       somehow need to get a default element... we can get this from the fact
+       that n < length xs, which implies that xs has at least one elemnt.
+
+       So I can imagine this could be automated with some appropriate hints. *)
+      destruct xs as [| x0 xs'] eqn:Hxs.
+      * replace (length nil) with 0 in pf.
+        apply (PeanoNat.Nat.nlt_0_r n). assumption.
+        auto.
+      * set (@nth_error_nth' X (x0::xs') n x0).
+        rewrite e in Heqo.
+        discriminate Heqo.
+        assumption.
+  Defined.
+
+  Lemma get_from_tail:
+    forall (xs : list X) (x: X)
+           (i : nat)
+           (pf: i < length xs)
+           (pf': (S i) < length (x::xs)),
+      (get (x::xs) (exist _ (S i) pf')) =
+      (get xs (exist _ i pf)).
+  Proof.
+    induction xs as [| x0 xs'].
+
+    - intros. exfalso.
+      nat_smaller_than_length_nil.
+
+    - destruct i as [| iminus1].
+      + unfold get. reflexivity.
+      + intros.
+        unfold get.
+        fold (get xs' (exist _ iminus1 (get_recursion_helper_dec pf))).
+        fold (get (x0::xs') (exist _ (S iminus1) (get_recursion_helper_dec pf'))).
+
+        specialize IHxs' with
+            (x := x)
+            (i := iminus1)
+            (pf := (get_recursion_helper_dec pf))
+            (pf' := (get_recursion_helper_dec pf')).
+        assumption.
+  Qed.
+
+  Lemma reduce_list_lengths_by_one:
+    forall (x: X) (xs: list X),
+      length (x :: xs) = S (length xs).
+  Proof. auto. Qed.
+
+  Ltac reduce_list_lengths :=
+    match goal with
+    | P: context [length (?x :: ?xs)]  |- _ => rewrite reduce_list_lengths_by_one in P
+    | P: context [length nil]  |- _ => rewrite length_nil in P
+    end.
+
+
+  Theorem is_sorted_via_indices (xs: list X):
+    (is_sorted xs) <->
+    (forall (i j: {n : nat | n < (length xs)}),
+        let (i0, _) := i in
+        let (j0, _) := j in
+        (i0 < j0) ->
+        (compare (get xs i) (get xs j) = Lt) \/
+        (compare (get xs i) (get xs j) = Eq)).
+  Proof.
+    split.
+    - induction xs as [|x0 xs'].
+      + intros.
+        exfalso.
+        nat_smaller_than_length_nil.
+
+      + intros.
+        destruct i as [i0 pfi].
+        destruct j as [j0 pfj].
+        intros.
+
+        match goal with
+          | [ H: is_sorted (?x :: ?xs) |- _ ] => set (tail_of_is_sorted_is_sorted H)
+        end.
+
+        destruct i0 as [| i0minus1].
+
+        * (* base case: use that x0 is leq the next element,
+           an by the induction hypothesis, that next element is leq the j-th element *)
+          destruct xs' as [| x1 xs''].
+          -- exfalso. (* xs' cannot be nil, bc 0 = i < j < length xs *)
+             repeat (reduce_list_lengths).
+             assert (j0 = 0) as Hj0.
+             apply PeanoNat.Nat.lt_1_r.
+             assumption.
+             subst.
+             apply (PeanoNat.Nat.lt_irrefl 0).
+             assumption.
+          -- assert ()
+
+
+
+
+
+
+
+
+             apply PeanoNat.Nat.lt_trans with (m := j0).
+             lia.
+             reduce_list_lengths.
+             reduce_list_lengths.
+             reduce_list_lengths.
+             rewrite reduce_list_lengths_by_one in pfi.
+
+             reduce_list_lengths.
+
+
+
+             nat_smaller_than_length_nil.
+
+          unfold get.
+
+        rewrite get_from_tail with (x := x0) (xs := xs').
+
+        destruct 
+
+
+
+
+
+
+        match goal with
+        | [ P : _ < length nil |- _ ] => rewrite (length_nil) in P
+        | [ P : ?x < 0 |- _ ] => apply PeanoNat.Nat.nlt_0_r with (n := x)
+        end.
+        match goal with
+        | [ P : _ < length nil |- _ ] => rewrite (length_nil) in P
+        | [ P : ?x < 0 |- _ ] => apply PeanoNat.Nat.nlt_0_r with (n := x)
+        end.
+        match goal
+        auto.
+        apply PeanoNat.Nat.nlt_0_r with (n := j0).
+        assumption.
+        assumption.
+
+        match goal with
+        | [ P : _ < length nil |- _ ] => replace (length nil) with 0 in P
+        end.
+        Locate "<".
+
+        auto.
+        intro.
+        unfold get.
+        auto.
+
+
+
+End indices.
 
 (* insert_sort is a helper function for sort *)
-Fixpoint insert_sort {A: Type} {cmp: comparable A} (xs: list A) (x: A) : list A :=
+Fixpoint insert_sort {X: Set} {tc: comparable X} (xs: list X) (x: X) : list X :=
   match xs with
   | nil => x :: nil
   | (x'::xs') => match compare x x' with
@@ -159,23 +472,25 @@ Fixpoint insert_sort {A: Type} {cmp: comparable A} (xs: list A) (x: A) : list A 
   end.
 
 (* insert_sort_sorts is a helper lemma for sort_sorts *)
-Lemma insert_sort_sorts: forall {A: Type} {cmp: comparable A} (xs: list A) (x: A) {s: is_sorted xs},
+Lemma insert_sort_sorts: forall {X: Set} {tc: comparable X} (xs: list X) (x: X) {s: is_sorted xs},
   is_sorted (insert_sort xs x).
 Proof.
 (* TODO: Good First Issue *)
 Admitted.
 
 (* sort is a helper function for eval_list_sort *)
-Fixpoint sort {A: Type} {cmp: comparable A} (xs: list A) : list A :=
+Fixpoint sort {X: Set} {tc: comparable X} (xs: list X) : list X :=
   match xs with
   | nil => nil
   | (x'::xs') => insert_sort (sort xs') x'
   end.
 
-Theorem sort_sorts: forall {A: Type} {cmp: comparable A} (xs: list A),
+Theorem sort_sorts: forall {X: Set} {tc: comparable X} (xs: list X),
   is_sorted (sort xs).
 Proof.
 induction xs.
 - simpl. trivial.
 - simpl. apply insert_sort_sorts. assumption.
 Qed.
+
+

--- a/src/sort.v
+++ b/src/sort.v
@@ -296,6 +296,9 @@ Section indices.
     (n < length xs) -> (S n < length (x :: xs)) :=
     fun (H : n < length (xs)) => Lt.lt_n_S n (length xs) H.
 
+  (* This tactic adds the hypothesis t only if there is not already a hypothesis
+  of type t in the context. Copied from
+  https://github.com/coq/coq/wiki/TacticExts#assert-if-necessary *)
   Local Ltac not_exist_hyp t :=
     match goal with
     | H1:t |- _ => fail 2

--- a/src/sort.v
+++ b/src/sort.v
@@ -472,47 +472,6 @@ Section indices.
         lia.
   Qed.
 
-
-  (*     erewrite get_from_tail with (x := x0) (xs := (xs' ++ ys)). *)
-
-
-  (*     get_proof_recursion_helpers_rewrite. *)
-  (*     Check (i - length xs'). *)
-
-  (*     intros. *)
-  (*     cbn in *. *)
-  (*     assert (i - 0 = i). *)
-  (*     lia. *)
-  (*     unfold get. *)
-  (*     cbn. *)
-  (*     trivial. *)
-  (*     reflexivity. *)
-  (*     exfalso. *)
-  (*     nat_smaller_than_length_nil. *)
-  (*   - destruct i as [| iminus1]. *)
-  (*     + unfold get. trivial. *)
-  (*     + *)
-  (*       replace ((x0 :: xs') ++ ys) with (x0 :: (xs' ++ ys)). *)
-  (*       2: { exact eq_refl. } *)
-  (*       intros. *)
-
-  (*       Local Ltac get_proof_recursion_helpers := *)
-  (*         match goal with *)
-  (*         | H: (S ?n < length (?x :: ?xs)) |- _ *)
-  (*           => assert_if_not_exist (n < length(xs)); try exact (@get_recursion_helper_dec n x xs H) *)
-  (*         end. *)
-
-  (*       (* All you need to do here is rewrite get_from_tail in two places, and *)
-  (*       then apply the induction hypothesis. *) *)
-
-  (*       repeat get_proof_recursion_helpers. *)
-  (*       unshelve erewrite get_from_tail. assumption. *)
-  (*       unshelve erewrite get_from_tail. assumption. *)
-
-  (*       apply IHxs'. *)
-  (* Qed. *)
-
-
   Theorem is_sorted_via_indices (xs: list X):
     (is_sorted xs) <->
     (forall (i j: {n : nat | n < (length xs)}),


### PR DESCRIPTION
This does quite a few things, but mainly:

- rename some `_assoc` properties to `_trans` (they are actually transitivity, not associativity; this is the least important change :p)
- make the inductive predicate definition of `is_sorted` the default
- prove a verified decision procedure for `is_sorted` (this is like a beefed-up version of the original `is_sort`)
- prove that our definition of `is_sorted` is the same as saying that for every pair of elements in a list, the element that comes first in the list is not larger than the element that comes later. (This is `Theorem is_sorted_via_indices`)

It's not the nicest code, but there are some interesting ideas, I think.