### PR TITLE
Adds an interpretation of a regex as a set of sequences.

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -21,6 +21,7 @@ src/smart_or.v
 src/smart.v
 src/simplified.v
 src/simple.v
+src/set_of_sequences.v
 
 src/inductive_predicate_experiment.v
 

--- a/src/set_of_sequences.v
+++ b/src/set_of_sequences.v
@@ -44,7 +44,7 @@ Theorem derive_is_derivative {A: Type} {cmd: comparable A} (a: A) (r: regex A):
   forall (xs: list A), xs \in |derive r a| <-> xs \in derive_sequence a (|r|).
 Abort.
 
-Lemma not_not : [1] \in |not (not (char 1))|.
+Example test_not_not_char : [1] \in |not (not (char 1))|.
 Proof.
   unfold  matching_sequences_for_regex.
   unfold Logic.not.
@@ -53,7 +53,7 @@ Proof.
   assumption.
 Qed.
 
-Lemma two_not_in : ~ ([2] \in |not (not (char 1))|).
+Example test_two_not_not_in_char_one : ~ ([2] \in |not (not (char 1))|).
 Proof.
   unfold  matching_sequences_for_regex.
   unfold Logic.not.
@@ -63,7 +63,7 @@ Proof.
   discriminate.
 Qed.
 
-Lemma concat_one : [1;2] \in |concat (char 1) (char 2)|.
+Example test_list_in_concat_one : [1;2] \in |concat (char 1) (char 2)|.
 Proof.
   unfold  matching_sequences_for_regex.
   exists [1].
@@ -71,7 +71,7 @@ Proof.
   repeat split; reflexivity.
 Qed.
 
-Lemma concat_two : ~([1;2;3] \in |concat (char 1) (char 2)|).
+Example test_list_not_in_concat_one_two : ~([1;2;3] \in |concat (char 1) (char 2)|).
 Proof.
   unfold  matching_sequences_for_regex.
   unfold Logic.not.
@@ -81,7 +81,7 @@ Proof.
   discriminate.
 Qed.
 
-Lemma star_one : [1] \in |star (char 1)|.
+Example test_one_in_star_char_one : [1] \in |star (char 1)|.
 Proof.
   unfold  matching_sequences_for_regex.
   constructor.

--- a/src/set_of_sequences.v
+++ b/src/set_of_sequences.v
@@ -7,6 +7,10 @@ Require Import nullable.
 Require Import regex.
 Require Import derive_def.
 
+(*
+  A set of sequences is interpreted as a value of `list A -> Prop`
+  where the sequence `list A` is in the set if the value on the sequence is `True`.
+*)
 Definition set_of_sequences {A: Type} {cmp: comparable A} := list A -> Prop.
 
 Notation "xs \in R" := (R xs) (at level 80).

--- a/src/set_of_sequences.v
+++ b/src/set_of_sequences.v
@@ -1,0 +1,44 @@
+Require Import List.
+Import ListNotations.
+Require Import Bool.
+
+Require Import comparable.
+Require Import nullable.
+Require Import regex.
+Require Import derive_def.
+
+Definition set_of_sequences {A: Type} {cmp: comparable A} := list A -> Prop.
+
+Notation "xs \in R" := (R xs) (at level 80).
+Notation "{ xs | P }" := (fun xs => P) (at level 0, xs at level 99).
+
+Reserved Notation "| r |" (at level 60).
+Reserved Notation "xs \in * R" (at level 80).
+
+Inductive matching_sequences_for_star {A: Type} {cmd: comparable A} (R: set_of_sequences): set_of_sequences :=
+| star_matches_nil : [] \in *R
+| star_matches_concat : forall xs ys,
+    xs \in R ->
+    ys \in *R ->
+    xs ++ ys \in *R
+where "xs \in * R" := ((matching_sequences_for_star R) xs).
+
+Fixpoint matching_sequences_for_regex {A: Type} {cmp: comparable A} (r: regex A): set_of_sequences :=
+  match r with
+  | fail => { _ | False }
+  | empty => { xs | xs = [] }
+  | char a => { xs | xs = [a] }
+  | or r1 r2 => { xs | xs \in |r1| \/ xs \in |r2| }
+  | and r1 r2 => { xs | xs \in |r1| /\ xs \in |r2| }
+  | concat r1 r2 => { xs | exists ys zs, xs = ys ++ xs /\ ys \in |r1| /\ zs \in |r2| }
+  | not r1 => { xs | ~ (xs \in |r1|) }
+  | star r1 => { xs | xs \in *|r1| }
+  end
+where "| r |" := (matching_sequences_for_regex r).
+
+Definition derive_sequence {A: Type} {cmd: comparable A} (a: A) (R: set_of_sequences) : set_of_sequences :=
+  { xs | (a :: xs) \in R }.
+
+Theorem derive_is_derivative {A: Type} {cmd: comparable A} (a: A) (r: regex A):
+  forall (xs: list A), xs \in |derive r a| <-> xs \in derive_sequence a (|r|).
+Admitted.


### PR DESCRIPTION
This leads to a simple definition of derivative.

A set of sequences is interpreted as a value of `list A -> Prop` where the sequence `list A` is in the set if the value on the sequence is `True`.