### PR TITLE
Remove duplicates from sorted list

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -3,6 +3,7 @@ src/orb_simple.v
 
 src/comparable.v
 src/sort.v
+src/list_set.v
 src/dup.v
 src/compare_nat.v
 src/reorder.v

--- a/src/comparable.v
+++ b/src/comparable.v
@@ -236,8 +236,6 @@ Lemma compare_leq_trans {A: Type} {cmp: comparable A} (x y z: A) :
 Proof.
   intros.
   unfold compare_leq in *.
-  Hint Resolve proof_compare_lt_trans.
-  Hint Resolve proof_compare_eq_trans.
 
   destruct H; destruct H0;
     try ((left; apply proof_compare_eq_trans with (y0 := y); assumption)
@@ -245,6 +243,15 @@ Proof.
     try (compare_to_eq; subst);
     try (left; assumption);
     try (right; assumption).
+Qed.
+
+Lemma compare_leq_reflex {A: Type} {cmp: comparable A} (x : A) :
+  (compare_leq x x).
+Proof.
+  intros.
+  unfold compare_leq.
+  left.
+  apply proof_compare_eq_reflex.
 Qed.
 
 Lemma compare_eq_dec {A: Type} {cmp: comparable A} (x y : A):

--- a/src/comparable.v
+++ b/src/comparable.v
@@ -279,3 +279,19 @@ Proof.
     left.
     reflexivity.
 Qed.
+
+(* If there is a pair of hypotheses
+          compare ?x0 ?x1 = Gt   and   compare ?x0 ?x1 = Lt (or = Eq)
+       then this tactic derives a contradiction.
+ *)
+Ltac contradiction_from_compares :=
+  match goal with
+  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Lt |- _ ]
+    => exfalso; assert (Gt = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Eq |- _ ]
+    => exfalso; assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  | [ H1: compare ?x0 ?x1 = Eq , H2: compare ?x0 ?x1 = Lt |- _ ]
+    => exfalso; assert (Eq = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  | [ H1: compare_leq ?x0 ?x1, H2: compare ?x0 ?x1 = Gt |- _ ]
+    => destruct H1; contradiction_from_compares
+  end.

--- a/src/comparable.v
+++ b/src/comparable.v
@@ -245,6 +245,18 @@ Proof.
     try (right; assumption).
 Qed.
 
+Lemma compare_lt_leq_trans {A: Type} {cmp: comparable A} (x y z: A) :
+  (compare x y = Lt)
+    -> (compare_leq y z)
+    -> (compare x z = Lt).
+Proof.
+  intros H1 H2.
+  destruct H2 as [H2 | H2].
+  - compare_to_eq.
+    subst. assumption.
+  - apply proof_compare_lt_trans with (y0 := y); assumption.
+Qed.
+
 Lemma compare_leq_reflex {A: Type} {cmp: comparable A} (x : A) :
   (compare_leq x x).
 Proof.

--- a/src/comparable.v
+++ b/src/comparable.v
@@ -246,3 +246,17 @@ Proof.
     try (left; assumption);
     try (right; assumption).
 Qed.
+
+Lemma compare_eq_dec {A: Type} {cmp: comparable A} (x y : A):
+  {x = y} + {x <> y}.
+Proof.
+  destruct (compare x y) eqn:Heqc;
+    try (right;
+         unfold not; intro;
+         subst;
+         rewrite proof_compare_eq_reflex in Heqc;
+         discriminate).
+  - compare_to_eq.
+    left.
+    reflexivity.
+Qed.

--- a/src/dup.v
+++ b/src/dup.v
@@ -2,9 +2,63 @@ Set Implicit Arguments.
 Set Asymmetric Patterns.
 
 Require Import List.
+Import ListNotations.
 
 Require Import comparable.
 Require Import sort.
+
+Section inductive_predicate_strictly_sorted.
+  (* Being strictly sorted can be defined in two equivalent ways:
+1. being sorted and having no duplicates; or
+2. every element in the list is strictly smaller than the next.
+   *)
+
+  Context {A: Type}.
+  Context {cmp: comparable A}.
+
+  Inductive is_strictly_sorted : list A -> Prop :=
+  | empty_strictly_sorted : is_strictly_sorted nil
+  | singleton_strictly_sorted (x : A) : is_strictly_sorted [x]
+  | tail_strictly_sorted (x y : A) (xs : list A):
+      (compare x y = Lt)
+      -> is_strictly_sorted (y :: xs)
+      -> is_strictly_sorted (x :: y :: xs).
+
+  Hint Constructors is_strictly_sorted : strictly_sorted.
+
+  Lemma is_strictly_sorted_tail: forall (ls : list A),
+      is_strictly_sorted ls -> is_strictly_sorted (tl ls).
+  Proof.
+    intro ls. intro H.
+    destruct H; auto with strictly_sorted.
+  Qed.
+End inductive_predicate_strictly_sorted.
+
+Section remove_duplicates_from_sorted.
+  Context {A: Type}.
+  Context {cmp: comparable A}.
+
+  (* The type of this function does not entirely specify the function: the
+     result may be a strictly sorted list, but there is nothing that says it is
+     the same as ls, but with duplicates removed. *)
+  Fixpoint remove_duplicates_from_sorted (ls : list A):
+      is_sorted ls -> {ls' : list A | is_strictly_sorted ls'}.
+    intro.
+    (* Probably need to do convoy trick here again. *)
+    refine (match ls with
+              | nil => (exist _ nil empty_strictly_sorted)
+              | (x0 :: xs')
+                => match xs' with
+                   | nil => (exist _ [x0] (singleton_strictly_sorted x0))
+                   | (x1 :: xs'') =>
+                     match compare x0 x1 with
+                     | Eq => remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H)
+                     | _ => x0 :: (remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H))
+                     end
+                   end
+            end).
+  Abort.
+End remove_duplicates_from_sorted.
 
 (* remove_duplicates_from_sorted removes duplicates from a sorted list *)
 Fixpoint remove_duplicates_from_sorted {A: Type} {cmp: comparable A} (xs: list A): list A :=

--- a/src/dup.v
+++ b/src/dup.v
@@ -6,6 +6,7 @@ Import ListNotations.
 
 Require Import comparable.
 Require Import sort.
+Require Import list_set.
 
 Section inductive_predicate_strictly_sorted.
   (* The following two properties of lists are equivalent:
@@ -131,115 +132,6 @@ Section remove_duplicates_from_sorted.
   Context {A: Type}.
   Context {cmp: comparable A}.
 
-  (* TODO: Help Wanted: isn't there some library that more or less does this?
-   The ones I found don't seem to have a notation of equality of sets. *)
-  Definition list_set_eq (xs ys : list A): Prop :=
-    forall (a : A), (In a xs) <-> (In a ys).
-
-  Hint Unfold list_set_eq: list_set_db.
-
-  (* Hint Extern extends an auto database with a tactic.
-   You can specify a cost (the natural number 0 in this case) and a
-   pattern to apply the tactic to.
-   See https://coq.inria.fr/refman/proof-engine/tactics.html#coq:cmdv.hint-extern *)
-  Hint Extern 0 (_ <-> _) => split : list_set_db.
-
-  Lemma list_set_eq_refl (xs: list A):
-    list_set_eq xs xs.
-  Proof.
-
-    auto with list_set_db.
-  Qed.
-
-  Hint Resolve list_set_eq_refl: list_set_db.
-
-  Lemma list_set_eq_symm (xs ys: list A):
-    list_set_eq xs ys <-> list_set_eq ys xs.
-  Proof.
-    easy.
-    (* Interesting note: auto doesn't solve this (even auto 10), but easy does. *)
-  Qed.
-
-  Lemma list_set_eq_step (a : A) (xs: list A):
-    list_set_eq (a::xs) (a::(a::xs)).
-  Proof.
-(* From the manual: "This tactic unfolds constants that were declared through a
-   Hint Unfold in the given databases."
-   https://coq.inria.fr/distrib/current/refman/proof-engine/tactics.html#coq:tacn.autounfold
-
-   In this case, I wanted to unfold list_set_eq. (We did `Hint Unfold list_set_eq:
-   list_set_db.` before.)
- *)
-    autounfold with list_set_db.
-    intros.
-    split.
-    - intro H.
-      unfold In.
-      destruct (compare_eq_dec a a0); auto.
-    - intro H.
-      unfold In.
-      (* Here auto doesn't work, because we need to destruct H twice
-       (one time we do it manually; one time, it happens in auto).
-       Is there some way we can add that as a kind of hint? *)
-      destruct (compare_eq_dec a a0).
-      + auto.
-      + unfold In in H.
-        destruct H; auto.
-  Qed.
-
-  Lemma list_set_eq_trans (xs ys zs : list A):
-    list_set_eq xs ys
-    -> list_set_eq ys zs
-    -> list_set_eq xs zs.
-  Proof.
-    intros.
-    unfold list_set_eq in *.
-    intro.
-    split.
-    - intro.
-      auto using H, H0 with list_set_db.
-      (* TODO: Help Wanted
-         How can the above auto statement fail to just apply the hints
-         I told it to apply?
-         The Coq manual does say (https://coq.inria.fr/distrib/current/refman/proof-engine/tactics.html#automation):
-
-         "auto uses a weaker version of apply that is closer to simple apply so it
-         is expected that sometimes auto will fail even if applying manually one
-         of the hints would succeed."
-
-         And indeed, `simple apply H0` does not work. So maybe that is the reason?
-
-         But then that raises the question: how do we get it to work? Should be
-         possible.
-       *)
-      apply H0.
-      apply H.
-      assumption.
-    - intro.
-      apply H.
-      apply H0.
-      assumption.
-  Qed.
-
-  Lemma list_set_eq_ind_step (xs ys: list A) (x : A):
-    list_set_eq xs ys ->
-    list_set_eq (x::xs) (x::ys).
-  Proof.
-    intros.
-    unfold list_set_eq.
-    intros.
-    split.
-    - intros H0.
-      destruct H0.
-      + subst. cbn. auto.
-      + subst. cbn. right.
-        apply H. assumption.
-    - intros H0.
-      destruct H0.
-      + subst. cbn. auto.
-      + subst. cbn. right.
-        apply H. assumption.
-  Qed.
 
   (* A verified decision procedure to remove all duplicate elements from a list
    that is sorted. The type tells you: given an input list ls, it returns a
@@ -373,7 +265,4 @@ Section remove_duplicates_from_sorted.
     Proof.
     (* TODO: Good First Issue *)
     Abort.
-
-
-
 End remove_duplicates_from_sorted.

--- a/src/dup.v
+++ b/src/dup.v
@@ -312,4 +312,8 @@ Section remove_duplicates_from_sorted.
       remember (first_two_of_is_sorted_are_sorted Hsort).
       contradiction_from_compares.
   Qed.
+
+  (* A convenience function that extracts the list from the above sigma type. *)
+  Definition remove_duplicates_from_sorted_list (ls : list A) (Hsort: is_sorted ls): list A
+    := (proj1_sig (sig_of_sig2 (remove_duplicates_from_sorted Hsort))).
 End remove_duplicates_from_sorted.

--- a/src/dup.v
+++ b/src/dup.v
@@ -33,6 +33,26 @@ Section inductive_predicate_strictly_sorted.
     destruct H; auto with strictly_sorted.
   Qed.
 
+  Local Ltac extract_info_from_strictly_sorted :=
+    unfold not; intros; subst;
+    match goal with
+    | [ H: is_strictly_sorted (?x0 :: ?xs) |- _ ]
+      => inversion H; subst;
+         try discriminate (* this eliminates some impossible cases *)
+    end;
+    destruct_list_equality.
+
+  Lemma is_strictly_sorted_implies_sorted: forall (ls : list A),
+      is_strictly_sorted ls -> is_sorted ls.
+  Proof.
+    induction ls.
+    - constructor.
+    - extract_info_from_strictly_sorted.
+      + constructor.
+      + constructor. left. assumption.
+        apply IHls. assumption.
+  Qed.
+
   Local Ltac is_strictly_sorted_contradiction_via_tail :=
     match goal with
     | [ H: is_strictly_sorted (?x0 :: ?xs),
@@ -52,14 +72,6 @@ Section inductive_predicate_strictly_sorted.
   Definition is_strictly_sorted_dec: forall (ls :list A),
       {is_strictly_sorted ls} + {~(is_strictly_sorted ls)}.
 
-    Local Ltac extract_info_from_strictly_sorted :=
-      unfold not; intros; subst;
-      match goal with
-      | [ H: is_strictly_sorted (?x0 :: ?xs) |- _ ]
-        => inversion H; subst;
-           try discriminate (* this eliminates some impossible cases *)
-      end;
-      destruct_list_equality.
 
     refine (
         fix F (ls: list A) : {is_strictly_sorted ls} + {~(is_strictly_sorted ls)} :=
@@ -100,6 +112,192 @@ End inductive_predicate_strictly_sorted.
 Section remove_duplicates_from_sorted.
   Context {A: Type}.
   Context {cmp: comparable A}.
+
+  (* HELP WANTED: isn't there some library that more or less does this?
+   The ones I found don't seem to have a notation of equality of sets. *)
+  Definition list_set_eq (xs ys : list A): Prop :=
+    forall (a : A), (In a xs) <-> (In a ys).
+
+  Hint Unfold list_set_eq: list_set_db.
+  Hint Extern 0 (_ <-> _) => split : list_set_db.
+
+  Lemma list_set_eq_refl (xs: list A):
+    list_set_eq xs xs.
+  Proof.
+    auto with list_set_db.
+  Qed.
+
+  Hint Resolve list_set_eq_refl: list_set_db.
+
+  Lemma list_set_eq_symm (xs ys: list A):
+    list_set_eq xs ys <-> list_set_eq ys xs.
+  Proof.
+    (* QUESTION: why can't auto do this? *)
+    split;
+      intro H;
+      unfold list_set_eq in *;
+      intro;
+      split; apply H.
+  Qed.
+
+  Lemma list_set_eq_step (a : A) (xs: list A):
+    list_set_eq (a::xs) (a::(a::xs)).
+  Proof.
+    autounfold with list_set_db.
+    intros.
+    split.
+    - intro H.
+      unfold In.
+      destruct (compare_eq_dec a a0); auto.
+    - intro H.
+      unfold In.
+      (* Here auto doesn't work, because we need to destruct H twice
+       (one time we do it manually; one time, it happens in auto).
+       Is there some way we can add that as a kind of hint? *)
+      destruct (compare_eq_dec a a0).
+      + auto.
+      + unfold In in H.
+        destruct H; auto.
+  Qed.
+
+  Lemma list_set_eq_trans (xs ys zs : list A):
+    list_set_eq xs ys
+    -> list_set_eq ys zs
+    -> list_set_eq xs zs.
+  Proof.
+    intros.
+    unfold list_set_eq in *.
+    intro.
+    split.
+    - intro.
+      auto using H, H0 with list_set_db.
+      (* QUESTION: how can the above auto statement fail to just apply the hints I told it to apply? *)
+      apply H0.
+      apply H.
+      assumption.
+    - intro.
+      apply H.
+      apply H0.
+      assumption.
+  Qed.
+
+  Lemma list_set_eq_ind_step (xs ys: list A) (x : A):
+    list_set_eq xs ys ->
+    list_set_eq (x::xs) (x::ys).
+  Proof.
+    intros.
+    unfold list_set_eq.
+    intros.
+    split.
+    - intros H0.
+      destruct H0.
+      + subst. cbn. auto.
+      + subst. cbn. right.
+        apply H. assumption.
+    - intros H0.
+      destruct H0.
+      + subst. cbn. auto.
+      + subst. cbn. right.
+        apply H. assumption.
+  Qed.
+
+  (* The result has to satisfy two properties:
+1. It is strictly sorted.
+2. As a set, it is equal to the input.
+   *)
+  Fixpoint remove_duplicates_from_sorted (ls : list A):
+    is_sorted ls ->
+    { lres : list A | is_strictly_sorted lres & list_set_eq ls lres }.
+    intros.
+    destruct ls as [| a0 ls'] eqn:?.
+    - subst.
+      refine (exist2 _ _ [] _ _).
+      + constructor.
+      + apply list_set_eq_refl.
+    - assert (is_sorted ls') as Hls'sorted.
+      apply tail_of_is_sorted_is_sorted with (x := a0).
+      assumption.
+
+      pose (remove_duplicates_from_sorted ls' Hls'sorted) as res.
+
+      destruct ls' as [| a1 ls''] eqn:?.
+
+      + refine (exist2 _ _ ls _ _).
+        subst. constructor. subst.
+        apply list_set_eq_refl.
+      + destruct (compare a0 a1) eqn:?.
+        * (* Case: a0 = a1 *)
+          refine (exist2 _ _
+                         (proj1_sig (sig_of_sig2 res))
+                         (proj2_sig (sig_of_sig2 res))
+                         _).
+
+          apply list_set_eq_trans with
+              (xs := (a0 :: a1 :: ls''))
+              (ys := ls')
+              (zs := (proj1_sig (sig_of_sig2 res))).
+          subst. compare_to_eq. subst.
+          apply list_set_eq_symm.
+          apply list_set_eq_step with (a := a1)
+                                      (xs := (ls'')).
+
+          subst.
+          exact (proj3_sig res).
+
+        * (* Case: a0 < a1 *)
+          set (res_list :=
+                 (proj1_sig (sig_of_sig2 res))).
+
+          refine (exist2 _ _
+                         (a0 :: res_list)
+                         _ _).
+
+          -- (* proof of strictly sorted *)
+             destruct res_list as [| res0 res_list' ] eqn:?; try constructor.
+             subst.
+
+             assert (compare_leq a1 res0).
+             (* Will use: a1 in  (a1 :: ls''), which is sorted;
+              res0 is also in there *)
+             assert (In res0 (a1 :: ls'')).
+             apply (proj3_sig res).
+             replace (proj1_sig (sig_of_sig2 res)) with res_list.
+             rewrite Heql1.
+             cbn. auto. auto.
+
+             replace a1 with (hd a1 (a1 :: ls'')).
+             apply is_sorted_first_element_smallest.
+             apply tail_of_is_sorted_is_sorted with (x := a0).
+             assumption.
+
+             assumption.
+             auto.
+
+             (* now use transitivity *)
+             apply compare_lt_leq_trans with (y := a1);
+             assumption.
+
+             subst.
+             rewrite <- Heql1.
+             exact (proj2_sig (sig_of_sig2 res)).
+
+          -- (* proof of list equality *)
+            (* idea of proof: both have a0; and the rest
+            of the list is equal by recursion. *)
+            apply list_set_eq_ind_step.
+            unfold res_list.
+            subst.
+            exact (proj3_sig res).
+
+        * (* Case a0 > a1; contradiction *)
+          exfalso.
+          remember (first_two_of_is_sorted_are_sorted H) as Hcontrad.
+          destruct Hcontrad; contradiction_from_compares.
+  Defined.
+
+
+
+
 
   (* The type of this function does not entirely specify the function: the
      result may be a strictly sorted list, but there is nothing that says it is

--- a/src/dup.v
+++ b/src/dup.v
@@ -32,6 +32,69 @@ Section inductive_predicate_strictly_sorted.
     intro ls. intro H.
     destruct H; auto with strictly_sorted.
   Qed.
+
+  Local Ltac is_strictly_sorted_contradiction_via_tail :=
+    match goal with
+    | [ H: is_strictly_sorted (?x0 :: ?xs),
+           Hcon: ~(is_strictly_sorted ?xs)
+        |- False ]
+      => apply Hcon;
+         apply is_strictly_sorted_tail;
+         exact H
+    | [ H: ~(is_strictly_sorted ?xs)
+        |- ~(is_strictly_sorted (?x0 :: ?xs))]
+        (* in this case, just apply the contrapositive of is_strictly_sorted_tail *)
+      => contradict H;
+         apply is_strictly_sorted_tail with (ls := (x0 :: xs));
+         assumption
+    end.
+
+  Definition is_strictly_sorted_dec: forall (ls :list A),
+      {is_strictly_sorted ls} + {~(is_strictly_sorted ls)}.
+
+    Local Ltac extract_info_from_strictly_sorted :=
+      unfold not; intros; subst;
+      match goal with
+      | [ H: is_strictly_sorted (?x0 :: ?xs) |- _ ]
+        => inversion H; subst;
+           try discriminate (* this eliminates some impossible cases *)
+      end;
+      destruct_list_equality.
+
+    refine (
+        fix F (ls: list A) : {is_strictly_sorted ls} + {~(is_strictly_sorted ls)} :=
+          (match ls
+                 return {is_strictly_sorted ls} +
+                        {~(is_strictly_sorted ls)}
+           with
+             | nil => left _
+             | (x0::ls') =>
+               (match ls' as l
+                      return (ls' = l) ->
+                             {is_strictly_sorted (x0::ls')} +
+                             {~(is_strictly_sorted (x0::ls'))}
+                with
+                | nil => (fun _ => left _)
+                | (x1::ls'') =>
+                  (fun ls0 =>
+                     (match (compare x0 x1) as cmp
+                            return (compare x0 x1 = cmp) ->
+                                   {is_strictly_sorted (x0::ls')} +
+                                   {~(is_strictly_sorted (x0::ls'))}
+                      with
+                      | Lt =>
+                        (fun Hcmp => if (F ls')
+                                     then left _
+                                     else right _)
+                      | _ =>
+                        (fun Hcmp => right _)
+                      end) eq_refl)
+                end) eq_refl
+           end));
+      try (subst; constructor; assumption);
+      try is_strictly_sorted_contradiction_via_tail;
+      try (extract_info_from_strictly_sorted; contradiction_from_compares).
+    Defined.
 End inductive_predicate_strictly_sorted.
 
 Section remove_duplicates_from_sorted.
@@ -45,18 +108,18 @@ Section remove_duplicates_from_sorted.
       is_sorted ls -> {ls' : list A | is_strictly_sorted ls'}.
     intro.
     (* Probably need to do convoy trick here again. *)
-    refine (match ls with
-              | nil => (exist _ nil empty_strictly_sorted)
-              | (x0 :: xs')
-                => match xs' with
-                   | nil => (exist _ [x0] (singleton_strictly_sorted x0))
-                   | (x1 :: xs'') =>
-                     match compare x0 x1 with
-                     | Eq => remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H)
-                     | _ => x0 :: (remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H))
-                     end
-                   end
-            end).
+    (* refine (match ls with *)
+    (*           | nil => (exist _ nil empty_strictly_sorted) *)
+    (*           | (x0 :: xs') *)
+    (*             => match xs' with *)
+    (*                | nil => (exist _ [x0] (singleton_strictly_sorted x0)) *)
+    (*                | (x1 :: xs'') => *)
+    (*                  match compare x0 x1 with *)
+    (*                  | Eq => remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H) *)
+    (*                  | _ => x0 :: (remove_duplicates_from_sorted xs' (tail_of_is_sorted_is_sorted H)) *)
+    (*                  end *)
+    (*                end *)
+    (*         end). *)
   Abort.
 End remove_duplicates_from_sorted.
 

--- a/src/list_set.v
+++ b/src/list_set.v
@@ -1,0 +1,122 @@
+(* This file contains some definitions and lemmas on using lists as sets. Mainly
+   we want to know whether two lists have the same set of elements (see the
+   definition of `list_set_eq`).
+ *)
+
+(* TODO: Help Wanted: isn't there some library that more or less does this?
+   The ones I found don't seem to have a notation of equality of sets. *)
+
+Set Implicit Arguments.
+Set Asymmetric Patterns.
+
+Require Import List.
+Import ListNotations.
+
+Section list_set_eq.
+  Context {A: Type}.
+
+  Definition list_set_eq (xs ys : list A): Prop :=
+    forall (a : A), (In a xs) <-> (In a ys).
+
+  Hint Unfold list_set_eq: list_set_db.
+
+  (* Hint Extern extends an auto database with a tactic.
+   You can specify a cost (the natural number 0 in this case) and a
+   pattern to apply the tactic to.
+   See https://coq.inria.fr/refman/proof-engine/tactics.html#coq:cmdv.hint-extern *)
+  Hint Extern 0 (_ <-> _) => split : list_set_db.
+
+  Lemma list_set_eq_refl (xs: list A):
+    list_set_eq xs xs.
+  Proof.
+    auto with list_set_db.
+  Qed.
+
+  Hint Resolve list_set_eq_refl: list_set_db.
+
+  Lemma list_set_eq_symm (xs ys: list A):
+    list_set_eq xs ys <-> list_set_eq ys xs.
+  Proof.
+    easy.
+    (* Interesting note: auto doesn't solve this (even auto 10), but easy does. *)
+  Qed.
+
+  Lemma list_set_eq_step (a : A) (xs: list A):
+    list_set_eq (a::xs) (a::(a::xs)).
+  Proof.
+(* From the manual: "This tactic unfolds constants that were declared through a
+   Hint Unfold in the given databases."
+   https://coq.inria.fr/distrib/current/refman/proof-engine/tactics.html#coq:tacn.autounfold
+
+   In this case, I wanted to unfold list_set_eq. (We did `Hint Unfold list_set_eq:
+   list_set_db.` before.)
+ *)
+    autounfold with list_set_db.
+    intros.
+    split.
+    - intro H.
+      unfold In.
+      auto.
+    - intro H.
+      unfold In in *.
+      destruct H; auto.
+      (* TODO: Help Wanted
+         Is there a way to do this entire proof in an automatised way?
+         We're only introducing, unfolding and destructing the logical disjunction H.
+       *)
+  Qed.
+
+  Lemma list_set_eq_trans (xs ys zs : list A):
+    list_set_eq xs ys
+    -> list_set_eq ys zs
+    -> list_set_eq xs zs.
+  Proof.
+    intros.
+    unfold list_set_eq in *.
+    intro.
+    split.
+    - intro.
+      auto using H, H0 with list_set_db.
+      (* TODO: Help Wanted
+         How can the above auto statement fail to just apply the hints
+         I told it to apply?
+         The Coq manual does say (https://coq.inria.fr/distrib/current/refman/proof-engine/tactics.html#automation):
+
+         "auto uses a weaker version of apply that is closer to simple apply so it
+         is expected that sometimes auto will fail even if applying manually one
+         of the hints would succeed."
+
+         And indeed, `simple apply H0` does not work. So maybe that is the reason?
+
+         But then that raises the question: how do we get it to work? Should be
+         possible.
+       *)
+      apply H0.
+      apply H.
+      assumption.
+    - intro.
+      apply H.
+      apply H0.
+      assumption.
+  Qed.
+
+  Lemma list_set_eq_ind_step (xs ys: list A) (x : A):
+    list_set_eq xs ys ->
+    list_set_eq (x::xs) (x::ys).
+  Proof.
+    intros.
+    unfold list_set_eq.
+    intros.
+    split.
+    - intros H0.
+      destruct H0.
+      + subst. cbn. auto.
+      + subst. cbn. right.
+        apply H. assumption.
+    - intros H0.
+      destruct H0.
+      + subst. cbn. auto.
+      + subst. cbn. right.
+        apply H. assumption.
+  Qed.
+End list_set_eq.

--- a/src/smart_or.v
+++ b/src/smart_or.v
@@ -482,13 +482,15 @@ Qed.
   (r + s) + t = r + (s + t)
   r + fail = r
 *)
-(*
-  I've commented this definition out, because it now requires a proof that the
-  result of (fold_left ....) is sorted, and I don't think we've proven that yet.
- *)
+(* TODO: Help Wanted
 
-(* Definition smart_or' {A: Type} {cmp: comparable A} (r s: regex A) : regex A :=
-   to_tree_or (remove_duplicates_from_sorted_list (fold_left insert_sort (to_list_or r) (to_list_or s))). *)
+  I've commented the definition below out, because it now requires a proof that
+  the result of (fold_left ....) is sorted, and I don't think we've proven that
+  yet.
+
+Definition smart_or' {A: Type} {cmp: comparable A} (r s: regex A) : regex A :=
+  to_tree_or (remove_duplicates_from_sorted_list (fold_left insert_sort (to_list_or r) (to_list_or s))).
+ *)
 
 (*
 merge_or_program merges two regexes.

--- a/src/smart_or.v
+++ b/src/smart_or.v
@@ -36,7 +36,7 @@ It should express that the tree is sorted and duplicates have been removed.
 (* TODO: Help Wanted
 Use the previous defined property `is_merge_or` to prove:
 ```
-merge_or_is_correct: forall {A: Type} {cmp: comparable A} 
+merge_or_is_correct: forall {A: Type} {cmp: comparable A}
   (r s: regex A) (is_merge_or r) (is_merge_or s),
   is_merge_or (merge_or r s)
 ```
@@ -482,8 +482,13 @@ Qed.
   (r + s) + t = r + (s + t)
   r + fail = r
 *)
-Definition smart_or' {A: Type} {cmp: comparable A} (r s: regex A) : regex A :=
-  to_tree_or (remove_duplicates_from_sorted (fold_left insert_sort (to_list_or r) (to_list_or s))).
+(*
+  I've commented this definition out, because it now requires a proof that the
+  result of (fold_left ....) is sorted, and I don't think we've proven that yet.
+ *)
+
+(* Definition smart_or' {A: Type} {cmp: comparable A} (r s: regex A) : regex A :=
+   to_tree_or (remove_duplicates_from_sorted_list (fold_left insert_sort (to_list_or r) (to_list_or s))). *)
 
 (*
 merge_or_program merges two regexes.

--- a/src/sort.v
+++ b/src/sort.v
@@ -240,6 +240,42 @@ Section lemmas.
     - fold (is_sortedb (y::xs)) in H.
       destruct (compare x y); (assumption || contradiction).
   Qed.
+
+  Lemma is_sorted_first_element_smallest (xs: list A) (default: A):
+    is_sorted (xs) ->
+    (forall (a: A),
+        In a xs -> compare_leq (hd default xs) a).
+  Proof.
+    induction xs as [| x0 xs'].
+    - intros Hsort a Hin.
+      unfold In in Hin. contradiction.
+    - intros Hsort a Hin.
+
+      destruct xs' as [| x1 xs''].
+      + cbn.
+        cbn in Hin.
+        destruct Hin.
+        * subst. unfold compare_leq.
+          left. apply proof_compare_eq_reflex.
+        * contradiction.
+
+      + cbn.
+        cbn in Hin.
+
+        destruct Hin as [Hin | [Hin | Hin]]; try subst.
+        * apply compare_leq_reflex.
+        * apply first_two_of_is_sorted_are_sorted with (xs := xs'').
+          assumption.
+        * (* proof is going to be: x0 leq x1, x1 leq x2 *)
+          apply compare_leq_trans with (y := x1).
+          -- apply first_two_of_is_sorted_are_sorted with (xs := xs'').
+             assumption.
+          -- apply IHxs'.
+             apply tail_of_is_sorted_is_sorted with (x := x0).
+             assumption.
+             unfold In in *.
+             right. assumption.
+  Qed.
 End lemmas.
 
 Theorem is_sorted_and_is_sortedb_are_equivalent : forall {A: Type} {cmp: comparable A} (xs: list A),

--- a/src/sort.v
+++ b/src/sort.v
@@ -156,9 +156,10 @@ Ltac contradiction_from_compares :=
     => exfalso; assert (Gt = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
   | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Eq |- _ ]
     => exfalso; assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-
   | [ H1: compare ?x0 ?x1 = Eq , H2: compare ?x0 ?x1 = Lt |- _ ]
     => exfalso; assert (Eq = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  | [ H1: compare_leq ?x0 ?x1, H2: compare ?x0 ?x1 = Gt |- _ ]
+    => destruct H1; contradiction_from_compares
   end.
 
 

--- a/src/sort.v
+++ b/src/sort.v
@@ -138,8 +138,9 @@ Qed.
    into two hypotheses
          x = y     and     xs = ys
 *)
-(* TODO: should this be moved somewhere else? Maybe make a library of tactics?
-Maybe a library of all kinds of list-related lemmas/tactics? *)
+(* TODO: Good First Issue
+move this to a library list.v
+That library should probably contain some other things spread throughout the code as well... *)
 Ltac destruct_list_equality :=
   repeat match goal with
          | [H: (?x :: ?xs) = (?y :: ?ys) |- _] => rewrite list_inductive_equality in H; destruct H

--- a/src/sort.v
+++ b/src/sort.v
@@ -138,10 +138,28 @@ Qed.
    into two hypotheses
          x = y     and     xs = ys
 *)
-Local Ltac destruct_list_equality :=
+(* TODO: should this be moved somewhere else? Maybe make a library of tactics? *)
+Ltac destruct_list_equality :=
   repeat match goal with
          | [H: (?x :: ?xs) = (?y :: ?ys) |- _] => rewrite list_inductive_equality in H; destruct H
          end.
+
+
+(* If there is a pair of hypotheses
+          compare ?x0 ?x1 = Gt   and   compare ?x0 ?x1 = Lt (or = Eq)
+       then this tactic derives a contradiction.
+ *)
+(* TODO: move to library? *)
+Ltac contradiction_from_compares :=
+  match goal with
+  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Lt |- _ ]
+    => exfalso; assert (Gt = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Eq |- _ ]
+    => exfalso; assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+
+  | [ H1: compare ?x0 ?x1 = Eq , H2: compare ?x0 ?x1 = Lt |- _ ]
+    => exfalso; assert (Eq = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
+  end.
 
 
 Section certified_decision_procedure.
@@ -165,18 +183,7 @@ Section certified_decision_procedure.
         => apply Hcon; apply tail_of_is_sorted_is_sorted with (x := x0); exact H
       end.
 
-    (* If there is a pair of hypotheses
-          compare ?x0 ?x1 = Gt   and   compare ?x0 ?x1 = Lt (or = Eq)
-       then this tactic derives a contradiction.
-     *)
-    Local Ltac contradiction_from_compares :=
-      exfalso;
-      match goal with
-      | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Lt |- _ ]
-        => assert (Gt = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-      | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Eq |- _ ]
-        => assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-      end.
+
 
     Hint Unfold compare_leq: sorted_db.
 

--- a/src/sort.v
+++ b/src/sort.v
@@ -138,30 +138,12 @@ Qed.
    into two hypotheses
          x = y     and     xs = ys
 *)
-(* TODO: should this be moved somewhere else? Maybe make a library of tactics? *)
+(* TODO: should this be moved somewhere else? Maybe make a library of tactics?
+Maybe a library of all kinds of list-related lemmas/tactics? *)
 Ltac destruct_list_equality :=
   repeat match goal with
          | [H: (?x :: ?xs) = (?y :: ?ys) |- _] => rewrite list_inductive_equality in H; destruct H
          end.
-
-
-(* If there is a pair of hypotheses
-          compare ?x0 ?x1 = Gt   and   compare ?x0 ?x1 = Lt (or = Eq)
-       then this tactic derives a contradiction.
- *)
-(* TODO: move to library? *)
-Ltac contradiction_from_compares :=
-  match goal with
-  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Lt |- _ ]
-    => exfalso; assert (Gt = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-  | [ H1: compare ?x0 ?x1 = Gt , H2: compare ?x0 ?x1 = Eq |- _ ]
-    => exfalso; assert (Gt = Eq); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-  | [ H1: compare ?x0 ?x1 = Eq , H2: compare ?x0 ?x1 = Lt |- _ ]
-    => exfalso; assert (Eq = Lt); try (rewrite <- H1; rewrite <- H2; reflexivity); discriminate
-  | [ H1: compare_leq ?x0 ?x1, H2: compare ?x0 ?x1 = Gt |- _ ]
-    => destruct H1; contradiction_from_compares
-  end.
-
 
 Section certified_decision_procedure.
   Context {A: Type}.


### PR DESCRIPTION
Main points:

* introduce an inductive predicate `is_strictly_sorted`: a list is strictly sorted if every element in the list is strictly smaller than (so not equal to) the next. Equivalently: it's a sorted list without duplicates.

* write a verified decision procedure that takes a sorted list and removes all its duplicates (i.e., it returns a strictly sorted list whose set of elements is equal to the set of elements of the list that we put in).