### PR TITLE
vscode settings to exclude files from sidebar

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+    "files.exclude": {
+        "**/.*.aux": true,
+        "**/.lia.cache": true,
+        "**/.Makefile.d": true,
+        "**/*.glob": true,
+        "**/*.vo": true,
+        "**/*.vok": true,
+        "**/*.vos": true,
+        "**/Makefile.conf": true
+    }
+}


### PR DESCRIPTION
Definitely questionable whether a specific editor's settings should be committed to the repo.
But it will make it a bit easier for me to switch between my home mac and the windows server for twitch streaming, so I don't have to reconfigure both.