### PR TITLE
Twitch Stream 9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ HASNATDYNLINK     := $(COQMF_HASNATDYNLINK)
 OCAMLWARN         := $(COQMF_WARN)
 
 Makefile.conf: _CoqProject
-	coq_makefile -f _CoqProject -o Makefile
+	C:\Coq\bin\coq_makefile.exe -f _CoqProject -o Makefile
 
 # This file can be created by the user to hook into double colon rules or
 # add any other Makefile code he may need

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ HASNATDYNLINK     := $(COQMF_HASNATDYNLINK)
 OCAMLWARN         := $(COQMF_WARN)
 
 Makefile.conf: _CoqProject
-	C:\Coq\bin\coq_makefile.exe -f _CoqProject -o Makefile
+	coq_makefile -f _CoqProject -o Makefile
 
 # This file can be created by the user to hook into double colon rules or
 # add any other Makefile code he may need

--- a/_CoqProject
+++ b/_CoqProject
@@ -33,6 +33,7 @@ src/Reexamined/smart_or.v
 src/Brzozowski/Alphabet.v
 src/Brzozowski/Boolean.v
 src/Brzozowski/Delta.v
+
 src/Brzozowski/ExampleR.v
 src/Brzozowski/Regex.v
 src/Brzozowski/Sequences.v

--- a/_CoqProject
+++ b/_CoqProject
@@ -33,7 +33,7 @@ src/Reexamined/smart_or.v
 src/Brzozowski/Alphabet.v
 src/Brzozowski/Boolean.v
 src/Brzozowski/Delta.v
-
+src/Brzozowski/Derive.v
 src/Brzozowski/ExampleR.v
 src/Brzozowski/Regex.v
 src/Brzozowski/Sequences.v

--- a/src/Brzozowski/Alphabet.v
+++ b/src/Brzozowski/Alphabet.v
@@ -1,6 +1,6 @@
 (* Alphabet is Sigma_k *)
-(* We are defining it here as a1 and x0, but we could do any disjoint set *)
-Inductive alphabet := a0 | a1.
+(* We are defining it here as A1 and A0, but we could do any disjoint set *)
+Inductive alphabet := A0 | A1.
 
 Lemma alphabet_disjoint: forall (x y: alphabet),
   x = y \/ x <> y.
@@ -23,7 +23,7 @@ Qed.
 
 Definition eqa (x y: alphabet): bool :=
   match (x, y) with
-  | (a0, a0) => true
-  | (a1, a1) => true
+  | (A0, A0) => true
+  | (A1, A1) => true
   | _ => false
   end.

--- a/src/Brzozowski/Alphabet.v
+++ b/src/Brzozowski/Alphabet.v
@@ -20,3 +20,10 @@ destruct x, y.
 - right. discriminate.
 - left. reflexivity.
 Qed. 
+
+Definition eqa (x y: alphabet): bool :=
+  match (x, y) with
+  | (a0, a0) => true
+  | (a1, a1) => true
+  | _ => false
+  end.

--- a/src/Brzozowski/Alphabet.v
+++ b/src/Brzozowski/Alphabet.v
@@ -1,6 +1,6 @@
 (* Alphabet is Sigma_k *)
 (* We are defining it here as a1 and x0, but we could do any disjoint set *)
-Inductive alphabet := a1 | a0.
+Inductive alphabet := a0 | a1.
 
 Lemma alphabet_disjoint: forall (x y: alphabet),
   x = y \/ x <> y.

--- a/src/Brzozowski/Boolean.v
+++ b/src/Brzozowski/Boolean.v
@@ -1,4 +1,8 @@
+Require Import List.
+Import ListNotations.
+
 Require Import CoqStock.WreckIt.
+Require Import CoqStock.Listerine.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Regex.
@@ -90,7 +94,7 @@ wreckit.
 unfold not.
 unfold "`elem`".
 intros.
-assumption.
+inversion H.
 Qed.
 
 Theorem notelem_emptyset: forall (s: seq),
@@ -100,7 +104,7 @@ intros.
 unfold not.
 cbn.
 intros.
-assumption.
+inversion H.
 Qed.
 
 Theorem notelem_intersection_l: forall (p q: regex) (s: seq),
@@ -157,7 +161,7 @@ apply H3.
 constructor.
 unfold not.
 constructor; assumption.
-Qed.  
+Qed.
 
 Lemma elem_or_notelem_symbol: forall (a: alphabet) (s: seq),
   s `elem` {{symbol a}} \/ s `notelem` {{symbol a}}.
@@ -167,16 +171,18 @@ induction s.
   unfold not.
   intros.
   inversion H.
+  listerine.
 - induction s.
   + induction a, a0.
-    * left. constructor.
-    * right. unfold not. intros. inversion H.
-    * right. unfold not. intros. inversion H.
-    * left. constructor.
+    * left. constructor. reflexivity.
+    * right. unfold not. intros. inversion H. listerine.
+    * right. unfold not. intros. inversion H. listerine.
+    * left. constructor. reflexivity.
   + right.
     unfold not.
     intros.
     inversion H.
+    discriminate.
 Qed.   
 
 Lemma elem_or_notelem_emptyset: forall (s: seq),
@@ -194,8 +200,8 @@ Lemma elem_or_notelem_lambda: forall (s: seq),
 Proof.
 intros.
 induction s.
-- left. constructor.
-- right. unfold not. intros. inversion H.
+- left. constructor. reflexivity.
+- right. unfold not. intros. inversion H. listerine.
 Qed.
 
 Lemma elem_or_notelem_concat: forall (r1 r2: regex) (s: seq),

--- a/src/Brzozowski/Boolean.v
+++ b/src/Brzozowski/Boolean.v
@@ -171,18 +171,16 @@ induction s.
   unfold not.
   intros.
   inversion H.
-  listerine.
 - induction s.
   + induction a, a0.
-    * left. constructor. reflexivity.
-    * right. unfold not. intros. inversion H. listerine.
-    * right. unfold not. intros. inversion H. listerine.
-    * left. constructor. reflexivity.
+    * left. constructor.
+    * right. unfold not. intros. inversion H.
+    * right. unfold not. intros. inversion H.
+    * left. constructor.
   + right.
     unfold not.
     intros.
     inversion H.
-    discriminate.
 Qed.   
 
 Lemma elem_or_notelem_emptyset: forall (s: seq),
@@ -200,8 +198,8 @@ Lemma elem_or_notelem_lambda: forall (s: seq),
 Proof.
 intros.
 induction s.
-- left. constructor. reflexivity.
-- right. unfold not. intros. inversion H. listerine.
+- left. constructor.
+- right. unfold not. intros. inversion H.
 Qed.
 
 Lemma elem_or_notelem_concat: forall (r1 r2: regex) (s: seq),

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -143,11 +143,11 @@ invs delta_p; invs delta_q; cbn; constructor; try untie.
 - constructor.
   exists []. exists []. exists eq_refl.
   split; assumption.
-- invs H1. wreckit. listerine. wreckit.
+- invs H1. wreckit. listerine. subst.
   apply H0. assumption.
-- invs H1. wreckit. listerine. wreckit.
+- invs H1. wreckit. listerine. subst.
   apply H. assumption.
-- invs H1. wreckit. listerine. wreckit.
+- invs H1. wreckit. listerine. subst.
   apply H. assumption.
 Qed.
 
@@ -415,21 +415,18 @@ induction r.
     invs H1.
     wreckit.
     listerine.
-    wreckit.
     contradiction.
   + apply delta_emptyset.
     untie.
     invs H1.
     wreckit.
     listerine.
-    wreckit.
     contradiction.
   + apply delta_emptyset.
     untie.
     invs H1.
     wreckit.
     listerine.
-    wreckit.
     contradiction.
 - cbn.
   apply delta_lambda.
@@ -476,7 +473,7 @@ inversion_clear H.
   + inversion H0.
   + cbn. reflexivity.
   + inversion H0.
-  + invs H0. wreckit. listerine. wreckit. subst.
+  + invs H0. wreckit. listerine. subst.
     remember (IHr1 L).
     remember (IHr2 R).
     cbn.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -1,6 +1,8 @@
 Require Import List.
 Import ListNotations.
 
+Require Import CoqStock.Listerine.
+
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Sequences.
@@ -41,6 +43,7 @@ Theorem delta_lambda_is_lambda: delta lambda lambda.
 Proof.
 apply delta_lambda.
 constructor.
+reflexivity.
 Qed.
 
 Theorem delta_emptyset_is_emptyset: delta emptyset emptyset.
@@ -59,6 +62,7 @@ apply delta_emptyset.
 unfold not.
 intros.
 inversion H.
+listerine.
 Qed.
 
 (*

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -98,6 +98,19 @@ split.
   inversion H.
 Qed.
 
+Theorem emptyset_terminates: forall (s: seq),
+  derive_seqs emptyset_seqs s
+  {<->}
+  emptyset_seqs.
+Proof.
+intros.
+split.
+- intros.
+  inversion H.
+- intros.
+  inversion H.
+Qed.
+
 (*
 **THEOREM 3.1.** If $R$ is a regular expression, 
 the derivative of $R$ with respect to a character $a \in \Sigma_k$ is found 
@@ -128,6 +141,9 @@ Fixpoint derive_def (r: regex) (a: alphabet) : regex :=
   | nor s t => nor (derive_def s a) (derive_def t a)
   end.
 
+Fixpoint derive_defs (r: regex) (s: seq) : regex :=
+  fold_left derive_def s r.
+
 Theorem commutes_a_emptyset: forall (a: alphabet),
   derive_seqs_a {{ emptyset }} a
   {<->}
@@ -136,6 +152,24 @@ Proof.
 intros.
 cbn.
 apply emptyset_terminates_a.
+Qed.
+
+Theorem commutes_emptyset: forall (s: seq),
+  derive_seqs {{ emptyset }} s
+  {<->}
+  {{ derive_defs emptyset s }}.
+Proof.
+intros.
+induction s.
+- cbn. apply emptyset_terminates.
+- split; intros.
+  + invs H.
+  + unfold seqs_eq in IHs.
+    cbn in H.
+    fold (derive_defs emptyset s) in H.
+    remember (IHs s0).
+    apply i in H.
+    invs H.
 Qed.
 
 Theorem commutes_a_lambda: forall (a: alphabet),
@@ -149,6 +183,32 @@ split.
   inversion H.
 - intros.
   inversion H.
+Qed.
+
+Theorem commutes_lambda: forall (s: seq),
+  derive_seqs {{ lambda }} s
+  {<->}
+  {{ derive_defs lambda s }}.
+Proof.
+intros.
+split.
+- intros.
+  inversion H.
+  listerine.
+  constructor.
+- intros.
+  induction s, s0.
+  + constructor.
+  + cbn in H.
+    invs H.
+  + cbn in H.
+    fold (derive_defs emptyset s) in H.
+    apply commutes_emptyset in H.
+    invs H.
+  + cbn in H.
+    fold (derive_defs emptyset s) in H.
+    apply commutes_emptyset in H.
+    invs H.
 Qed.
 
 Theorem commutes_a_symbol: forall (a b: alphabet),
@@ -169,6 +229,14 @@ split; intros.
   + inversion H.
   + invs H. constructor.
 Qed.
+
+Theorem commutes_symbol: forall (b: alphabet) (s: seq),
+  derive_seqs {{ symbol b }} s
+  {<->}
+  {{ derive_defs (symbol b) s }}.
+Proof.
+(* TODO: Help Wanted *)
+Abort.
 
 Theorem concat_seqs_a_impl_def: forall (r1 r2: regex) (a: alphabet),
   derive_seqs_a {{r1}} a {->} {{derive_def r1 a}} ->
@@ -267,10 +335,18 @@ split.
   invs R0.
 Qed.
 
-Theorem derive_commutes: forall (r: regex) (a: alphabet),
+Theorem derive_commutes_a: forall (r: regex) (a: alphabet),
   derive_seqs_a {{ r }} a
   {<->}
   {{ derive_def r a }}.
+Proof.
+(* TODO: Help Wanted *)
+Abort.
+
+Theorem derive_commutes: forall (r: regex) (s: seq),
+  derive_seqs {{ r }} s
+  {<->}
+  {{ derive_defs r s }}.
 Proof.
 (* TODO: Help Wanted *)
 Abort.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -11,7 +11,7 @@ Require Import Brzozowski.Delta.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Sequences.
 
-(* D_a R = {t | a.t \in R} *)
+(* D_a R = { t | a.t \in R} *)
 Definition derive_seqs (R: seqs) (a: alphabet) (t: seq): Prop :=
   (a :: t) `elem` R.
 
@@ -22,72 +22,11 @@ Inductive derive_seqs' (R: seqs) (a: alphabet) (t: seq): Prop :=
     t `elem` (derive_seqs' R a)
   .
 
-Definition seqs_eq (s1 s2: seqs): Prop :=
-   forall (s: seq),
-   s `elem` s1 <-> s `elem` s2.
-
-Notation "s1 `seqs_eq` s2" := (seqs_eq s1 s2) (at level 80).
-
-Theorem derive_seqs_emptyset_a0:
-    derive_seqs {{ emptyset }} a0
-    `seqs_eq`
-    {{ emptyset }}.
-Proof.
-unfold seqs_eq.
-intros.
-split.
-- intros.
-  inversion_clear H.
-- intros.
-  inversion_clear H.
-Qed.
-
-Theorem derive_seqs_lambda_a0:
-    derive_seqs {{ lambda }} a0
-    `seqs_eq`
-    {{ emptyset }}.
-Proof.
-unfold seqs_eq.
-split.
-- intros.
-  inversion_clear H.
-- intros.
-  inversion_clear H.
-Qed. 
-
-Theorem derive_seqs_symbol_a0:
-    derive_seqs {{ symbol a0 }} a0
-    `seqs_eq`
-    {{ lambda }}.
-Proof.
-unfold seqs_eq.
-split.
-- intros.
-  inversion_clear H.
-  constructor.
-- intros.
-  inversion_clear H.
-  apply mk_derive_seqs.
-  constructor.
-Qed.
-
-Theorem derive_seqs_symbol_a1:
-    derive_seqs {{ symbol a0 }} a1
-    `seqs_eq`
-    {{ emptyset }}.
-Proof.
-unfold seqs_eq.
-split.
-- intros.
-  inversion_clear H.
-- intros.
-  inversion_clear H.
-Qed.
-
-Theorem derive_seqs_star_a0:
-  derive_seqs {{ star (symbol a0) }} a0
-  `seqs_eq`
-  {{ star (symbol a0) }}.
+Theorem derive_seqs_star:
+  forall (a: alphabet),
+  derive_seqs {{ star (symbol a) }} a
+  {<->}
+  {{ star (symbol a) }}.
 Proof.
 split.
 - intros.
@@ -103,7 +42,7 @@ split.
   + apply mk_star_more.
     subst.
     constructor.
-    exists [a0].
+    exists [a].
     exists [].
     exists eq_refl.
     split.
@@ -119,20 +58,33 @@ split.
     inversion L.
     subst.
     constructor.
-    exists [a0].
-    exists (a0 :: x0).
+    exists [a].
+    exists (a :: x0).
     exists eq_refl.
     split.
     -- constructor.
     -- apply mk_star_more.
        constructor.
-       exists [a0].
+       exists [a].
        exists x0.
        exists eq_refl.
        split.
        ++ constructor.
        ++ cbn in R.
           exact R.
+Qed.
+
+Theorem emptyset_terminates: forall (a: alphabet),
+  derive_seqs emptyset_seqs a
+  {<->}
+  emptyset_seqs.
+Proof.
+intros.
+split.
+- intros.
+  inversion H.
+- intros.
+  inversion H.
 Qed.
 
 Fixpoint derive_def (r: regex) (a: alphabet) : regex :=
@@ -150,20 +102,9 @@ Fixpoint derive_def (r: regex) (a: alphabet) : regex :=
   | nor s t => nor (derive_def s a) (derive_def t a)
   end.
 
-Theorem emptyset_terminates: forall (a: alphabet),
-  derive_seqs emptyset_seqs a `seqs_eq` emptyset_seqs.
-Proof.
-intros.
-split.
-- intros.
-  inversion H.
-- intros.
-  inversion H.
-Qed.
-
 Theorem commutes_emptyset: forall (a: alphabet),
   derive_seqs {{ emptyset }} a
-  `seqs_eq`
+  {<->}
   {{ derive_def emptyset a }}.
 Proof.
 intros.
@@ -173,7 +114,7 @@ Qed.
 
 Theorem commutes_lambda: forall (a: alphabet),
   derive_seqs {{ lambda }} a
-  `seqs_eq`
+  {<->}
   {{ derive_def lambda a }}.
 Proof.
 intros.
@@ -186,7 +127,7 @@ Qed.
 
 Theorem commutes_symbol: forall (a b: alphabet),
   derive_seqs {{ symbol b }} a
-  `seqs_eq`
+  {<->}
   {{ derive_def (symbol b) a }}.
 Proof.
 intros.
@@ -202,131 +143,3 @@ split; intros.
   + inversion H.
   + invs H. constructor.
 Qed.
-
-Theorem commutes_concat: forall (s t: regex) (a: alphabet),
-  derive_seqs {{s}} a `seqs_eq` {{derive_def s a}} ->
-  derive_seqs {{t}} a `seqs_eq` {{derive_def t a}} ->
-  derive_seqs {{ concat s t }} a
-  `seqs_eq`
-  {{ derive_def (concat s t) a }}.
-Proof.
-intros.
-split; intros.
-- invs H1. wreckit. cbn. constructor. wreckit.
-  untie.
-  invs H1.
-  wreckit.
-  listerine.
-  apply delta_lambda in L.
-  apply delta_implies_delta_def in L.
-  + apply H0 in R.
-    apply R0.
-    constructor.
-    exists [].
-    exists s0.
-    exists eq_refl.
-    split.
-    * rewrite L.
-      constructor.
-    * assumption.
-  + apply H in L.
-    apply L0.
-    constructor.
-    exists L1.
-    exists x0.
-    exists eq_refl.
-    split.
-    * assumption.
-    * assumption.
-- cbn.
-  inversion_clear H1.
-  wreckit.
-  induction s.
-  + exfalso. apply R.
-    constructor.
-    split.
-    * untie.
-      inversion_clear H1.
-      wreckit.
-      inversion L0.
-    * untie.
-      inversion_clear H1.
-      wreckit.
-      inversion L0.
-  + constructor.
-    exists [].
-    exists (a :: s0).
-    exists eq_refl.
-    split.
-    * constructor.
-    * induction t.
-      -- exfalso.
-         apply R.
-         constructor.
-         split.
-         ++ untie.
-            inversion H1.
-            wreckit.
-            inversion R0.
-         ++ untie.
-            inversion H1.
-            wreckit.
-            inversion R0.
-      -- exfalso.
-         apply R.
-         constructor.
-         split.
-         ++ untie.
-            inversion H1.
-            wreckit.
-            inversion L0.
-         ++ untie.
-            inversion H1.
-            wreckit.
-            inversion R0.
-      -- destruct s0.
-         ++ destruct a.
-            ** exfalso.
-               apply R.
-               constructor.
-               split.
-               --- untie.
-                   inversion H1.
-                   wreckit.
-                   inversion L0.
-               --- untie.
-                   inversion H1.
-                   wreckit.
-                   inversion L0.
-                   listerine.
-                   wreckit.
-                   subst.
-                   cbn in R0.
-                   destruct a0.
-                   +++ inversion R0. 
-
-                   inversion R1.
-                   cbn in R0.
-                   inversion R0. 
-
-  
-
-   
-   
-  
-
-
-
-
-Theorem commutes: forall (r: regex) (a: alphabet),
-  derive_seqs {{ r }} a
-  `seqs_eq`
-  {{ derive_def r a }}.
-Proof.
-intros.
-induction r.
-- apply commutes_emptyset.
-- apply commutes_lambda.
-- apply commutes_symbol.
--   
-  

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -143,3 +143,108 @@ split; intros.
   + inversion H.
   + invs H. constructor.
 Qed.
+
+Theorem concat_seqs_impl_def: forall (r1 r2: regex) (a: alphabet),
+  derive_seqs {{r1}} a {->} {{derive_def r1 a}} ->
+  derive_seqs {{r2}} a {->} {{derive_def r2 a}} ->
+  (
+    derive_seqs {{ concat r1 r2 }} a
+    {->}
+    {{ derive_def (concat r1 r2) a }}
+  ).
+Proof.
+unfold seqs_impl.
+intros r1 r2 a R1 R2 s C.
+invs C. 
+wreckit.
+cbn.
+constructor.
+wreckit.
+untie.
+invs H.
+wreckit.
+listerine.
+- apply delta_lambda in L.
+  apply delta_implies_delta_def in L.
+  apply R2 in R.
+  apply R0.
+  constructor.
+  exists [].
+  exists s.
+  exists eq_refl.
+  split.
+  + rewrite L.
+    constructor.
+  + assumption.
+- apply R1 in L.
+  apply L0.
+  constructor.
+  exists L1.
+  exists x0.
+  exists eq_refl.
+  split.
+  * assumption.
+  * assumption.
+Qed.
+
+Theorem concat_emptyset_l_def_impl_seqs:
+  forall (r2: regex) (a: alphabet),
+  (
+    {{ derive_def (concat emptyset r2) a }}
+    {->}
+    derive_seqs {{ concat emptyset r2 }} a
+  ).
+Proof.
+unfold "{->}".
+intros r2 a s C.
+cbn in C.
+invs C.
+wreckit.
+exfalso.
+apply R.
+constructor.
+split.
+- untie.
+  invs H.
+  wreckit.
+  invs L0.
+- untie.
+  invs H.
+  wreckit.
+  invs L0.
+Qed.
+
+Theorem concat_emptyset_r_def_impl_seqs:
+  forall (r1: regex) (a: alphabet),
+  (
+    {{ derive_def (concat r1 emptyset) a }}
+    {->}
+    derive_seqs {{ concat r1 emptyset }} a
+  ).
+Proof.
+unfold "{->}".
+intros r1 a s C.
+cbn in C.
+invs C.
+wreckit.
+exfalso.
+apply R.
+constructor.
+split.
+- untie.
+  invs H.
+  wreckit.
+  invs R0.
+- untie.
+  invs H.
+  wreckit.
+  invs R0.
+Qed.
+
+Theorem derive_commutes: forall (r: regex) (a: alphabet),
+  derive_seqs {{ r }} a
+  {<->}
+  {{ derive_def r a }}.
+Proof.
+(* TODO: Help Wanted *)
+Abort.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -1,0 +1,242 @@
+Require Import List.
+Import ListNotations.
+
+Require Import CoqStock.WreckIt.
+Require Import CoqStock.Listerine.
+Require Import CoqStock.Invs.
+
+Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.Delta.
+Require Import Brzozowski.Regex.
+Require Import Brzozowski.Sequences.
+
+(* D_a R = {t | a.t \in R} *)
+Definition derive_seqs (R: seqs) (a: alphabet) (t: seq): Prop :=
+  (a :: t) `elem` R.
+
+(* Alternative inductive predicate for derive_seqs *)
+Inductive derive_seqs' (R: seqs) (a: alphabet) (t: seq): Prop :=
+  | mk_derive_seqs:
+    (a :: t) `elem` R ->
+    t `elem` (derive_seqs' R a)
+  .
+
+Definition seqs_eq (s1 s2: seqs): Prop :=
+   forall (s: seq),
+   s `elem` s1 <-> s `elem` s2.
+
+Notation "s1 `seqs_eq` s2" := (seqs_eq s1 s2) (at level 80).
+
+Theorem derive_seqs_emptyset_a0:
+    derive_seqs {{ emptyset }} a0
+    `seqs_eq`
+    {{ emptyset }}.
+Proof.
+unfold seqs_eq.
+intros.
+split.
+- intros.
+  inversion_clear H.
+- intros.
+  inversion_clear H.
+Qed.
+
+Theorem derive_seqs_lambda_a0:
+    derive_seqs {{ lambda }} a0
+    `seqs_eq`
+    {{ emptyset }}.
+Proof.
+unfold seqs_eq.
+split.
+- intros.
+  inversion_clear H.
+  discriminate.
+- intros.
+  inversion_clear H.
+Qed. 
+
+Theorem derive_seqs_symbol_a0:
+    derive_seqs {{ symbol a0 }} a0
+    `seqs_eq`
+    {{ lambda }}.
+Proof.
+unfold seqs_eq.
+split.
+- intros.
+  inversion_clear H.
+  constructor.
+  listerine.
+- intros.
+  inversion_clear H.
+  apply mk_derive_seqs.
+  constructor.
+  subst.
+  reflexivity.
+Qed.
+
+Theorem derive_seqs_symbol_a1:
+    derive_seqs {{ symbol a0 }} a1
+    `seqs_eq`
+    {{ emptyset }}.
+Proof.
+unfold seqs_eq.
+split.
+- intros.
+  inversion_clear H.
+  listerine.
+- intros.
+  inversion_clear H.
+Qed.
+
+Theorem derive_seqs_star_a0:
+  derive_seqs {{ star (symbol a0) }} a0
+  `seqs_eq`
+  {{ star (symbol a0) }}.
+Proof.
+split.
+- intros.
+  inversion_clear H.
+  + inversion H0.
+  + inversion H0.
+    wreckit.
+    inversion L.
+    listerine.
+    assumption.
+- intros.
+  inversion_clear H.
+  + apply mk_star_more.
+    subst.
+    constructor.
+    exists [a0].
+    exists [].
+    exists eq_refl.
+    split.
+    * constructor. reflexivity.
+    * apply mk_star_zero.
+      reflexivity.
+  + inversion_clear H0.
+    wreckit.
+    subst.
+    unfold derive_seqs.
+    cbn.
+    apply mk_star_more.
+    inversion L.
+    subst.
+    constructor.
+    exists [a0].
+    exists (a0 :: x0).
+    exists eq_refl.
+    split.
+    -- constructor. reflexivity.
+    -- apply mk_star_more.
+       constructor.
+       exists [a0].
+       exists x0.
+       exists eq_refl.
+       split.
+       ++ constructor. reflexivity.
+       ++ cbn in R.
+          exact R.
+Qed.
+
+Fixpoint delta_def (r: regex): regex :=
+match r with
+| emptyset => emptyset
+| lambda => lambda
+| symbol _ => emptyset
+| concat s t => match (delta_def s, delta_def t) with
+  | (lambda, lambda) => lambda
+  | _ => emptyset
+  end
+| star s => lambda
+| nor s t => 
+    match (delta_def s, delta_def t) with
+    | (emptyset, emptyset) => lambda
+    | _ => emptyset
+    end
+end.
+
+Fixpoint derive_def (r: regex) (a: alphabet) : regex :=
+  match r with
+  | emptyset => emptyset
+  | lambda => emptyset
+  | symbol b => 
+    if (eqa b a)
+    then lambda
+    else emptyset
+  | concat s t =>
+    or (concat (derive_def s a) t) 
+       (concat (delta_def s) (derive_def t a))
+  | star s => concat (derive_def s a) (star s)
+  | nor s t => nor (derive_def s a) (derive_def t a)
+  end.
+
+Theorem emptyset_terminates: forall (a: alphabet),
+  derive_seqs emptyset_seqs a `seqs_eq` emptyset_seqs.
+Proof.
+intros.
+split.
+- intros.
+  inversion H.
+- intros.
+  inversion H.
+Qed.  
+
+Theorem commutes_emptyset: forall (a: alphabet),
+  derive_seqs {{ emptyset }} a
+  `seqs_eq`
+  {{ derive_def emptyset a }}.
+Proof.
+intros.
+cbn.
+apply emptyset_terminates.
+Qed.
+
+Theorem commutes_lambda: forall (a: alphabet),
+  derive_seqs {{ lambda }} a
+  `seqs_eq`
+  {{ derive_def lambda a }}.
+Proof.
+intros.
+split.
+- intros.
+  inversion H.
+  discriminate.
+- intros.
+  inversion H.
+Qed.
+
+Theorem commutes_symbol: forall (a b: alphabet),
+  derive_seqs {{ symbol b }} a
+  `seqs_eq`
+  {{ derive_def (symbol b) a }}.
+Proof.
+intros.
+split; intros.
+- inversion H.
+  subst.
+  destruct a, b; cbn.
+  + constructor.
+    listerine.
+  + discriminate.
+  + discriminate.
+  + constructor.
+    listerine.
+- destruct a, b; cbn in H.
+  + invs H. constructor. reflexivity.
+  + inversion H.
+  + inversion H.
+  + invs H. constructor. reflexivity.
+Qed.   
+
+
+Theorem commutes: forall (r: regex) (a: alphabet),
+  derive_seqs {{ r }} a
+  `seqs_eq`
+  {{ derive_def r a }}.
+Proof.
+intros.
+induction r.
+- apply commutes_emptyset.
+- 
+  

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -17,29 +17,29 @@ The desired expression is easily seen to be:
 
 R = (I.1.1.1.I)\&(I.0.1+1.1^{*})'.
 *)
-Definition x1 := symbol a1.
-Definition x0 := symbol a0.
+Definition x1 := symbol A1.
+Definition x0 := symbol A0.
 Definition xI111I := concat I (concat x1 (concat x1 (concat x1 I))).
 Definition xI01 := concat I (concat x0 x1).
 Definition x11star := concat x1 (star x1).
 Definition exampleR := and xI111I (complement (or xI01 x11star)).
 
 Lemma test_elem_xI01_101:
-  ([a1] ++ [a0] ++ [a1]) `elem` {{xI01}}.
+  ([A1] ++ [A0] ++ [A1]) `elem` {{xI01}}.
 Proof.
 unfold xI01.
 constructor.
-exists [a1].
-exists ([a0] ++ [a1]).
-assert ([a1] ++ [a0] ++ [a1] = [a1; a0; a1]). reflexivity.
+exists [A1].
+exists ([A0] ++ [A1]).
+assert ([A1] ++ [A0] ++ [A1] = [A1; A0; A1]). reflexivity.
 exists H.
 constructor.
 - constructor.
   wreckit.
   apply notelem_emptyset.
 - constructor.
-  exists [a0].
-  exists [a1].
+  exists [A0].
+  exists [A1].
   exists eq_refl.
   constructor.
   + constructor.
@@ -47,7 +47,7 @@ constructor.
 Qed.
 
 Lemma test_notelem_xI01_101_false:
-  ([a1] ++ [a0] ++ [a1]) `notelem` {{xI01}}  -> False.
+  ([A1] ++ [A0] ++ [A1]) `notelem` {{xI01}}  -> False.
 Proof.
 unfold not.
 intros.
@@ -74,7 +74,7 @@ subst.
 cbn in x3.
 apply app_eq_nil in x3.
 wreckit.
-assert ([a0; a1] <> []).
+assert ([A0; A1] <> []).
 discriminate.
 subst.
 elemt.
@@ -84,7 +84,7 @@ contradiction.
 Qed.
 
 Lemma test_notelem_xI01_10:
-  ([a1] ++ [a0]) `notelem` {{xI01}}.
+  ([A1] ++ [A0]) `notelem` {{xI01}}.
 Proof.
 elemt.
 elemt.
@@ -96,13 +96,13 @@ elemt.
 elemt.
 wreckit.
 subst.
-assert (x ++ [a0] ++ [a1] <> [a1] ++ [a0]).
+assert (x ++ [A0] ++ [A1] <> [A1] ++ [A0]).
 listerine.
 contradiction.
 Qed.
 
 Lemma test_notelem_xI01_1110:
-  ([a1] ++ [a1] ++ [a1] ++ [a0]) `notelem` {{xI01}}.
+  ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{xI01}}.
 Proof.
 elemt.
 elemt.
@@ -117,7 +117,7 @@ listerine.
 Qed.
 
 Lemma test_notelem_x11star_0: 
-  [a0] `notelem` {{ x11star }}.
+  [A0] `notelem` {{ x11star }}.
 Proof.
 elemt.
 elemt.
@@ -137,7 +137,7 @@ elemt.
 Qed.
 
 Lemma test_notelem_x11star_1110: 
-    ([a1] ++ [a1] ++ [a1] ++ [a0]) `notelem` {{x11star}}.
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{x11star}}.
 Proof.
 (* TODO: Good First Issue
    first merge listerine
@@ -145,7 +145,7 @@ Proof.
 Abort.
 
 Lemma test_elem_xI111I_1110: 
-    ([a1] ++ [a1] ++ [a1] ++ [a0]) `elem` {{xI111I}}.
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
 Proof.
 (* TODO: Good First Issue
    first merge listerine
@@ -153,7 +153,7 @@ Proof.
 Abort.
 
 Theorem test_exampleR_1110_elem: 
-    ([a1] ++ [a1] ++ [a1] ++ [a0]) `elem` {{exampleR}}.
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{exampleR}}.
 Proof.
 (* TODO: Good First Issue
    first merge listerine
@@ -162,7 +162,7 @@ Abort.
 
 
 Theorem test_exampleR_111_notelem: 
-    [a1; a1; a1] `notelem` {{exampleR}}.
+    [A1; A1; A1] `notelem` {{exampleR}}.
 Proof.
 (* TODO: Good First Issue
    first merge listerine

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -42,8 +42,8 @@ constructor.
   exists [a1].
   exists eq_refl.
   constructor.
-  + constructor.
-  + constructor.
+  + constructor. reflexivity.
+  + constructor. reflexivity.
 Qed.
 
 Lemma test_notelem_xI01_101_false:
@@ -124,10 +124,15 @@ elemt.
 wreckit.
 elemt.
 - subst.
-  cbn in x3.
+  listerine.
+  subst.
+  elemt.
   discriminate.
 - elemt.
   wreckit.
+  subst.
+  inversion L.
+  inversion L0.
   subst.
   listerine.
 Qed.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -42,8 +42,8 @@ constructor.
   exists [a1].
   exists eq_refl.
   constructor.
-  + constructor. reflexivity.
-  + constructor. reflexivity.
+  + constructor.
+  + constructor.
 Qed.
 
 Lemma test_notelem_xI01_101_false:
@@ -127,7 +127,6 @@ elemt.
   listerine.
   subst.
   elemt.
-  discriminate.
 - elemt.
   wreckit.
   subst.

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -47,15 +47,33 @@ Inductive nor_seqs (P Q: seqs): seqs :=
     nor_seqs P Q s
   .
 
+Inductive emptyset_seqs: seqs :=
+  (* | mk_emptyset: forall (s: seq),
+    False ->
+    emptyset_seqs s *)
+  .
+
+Inductive lambda_seqs: seqs :=
+  | mk_lambda: forall (s: seq),
+    s = [] ->
+    lambda_seqs s
+  .
+
+Inductive symbol_seqs (a: alphabet): seqs :=
+  | mk_symbol: forall (s: seq),
+    s = [a] ->
+    symbol_seqs a s
+  .
+
 (* Here we use a mix of Fixpoint and Inductive predicates to define the denotation of regular expressions.
    This works, but it would be nicer to define it purely as an Inductive predicate.
 *)
 Reserved Notation "{{ r }}" (r at level 60, no associativity).
 Fixpoint denote_regex (r: regex): seqs :=
   match r with
-  | emptyset => fun _ => False
-  | lambda => fun xs => xs = []
-  | symbol y => fun xs => xs = [y]
+  | emptyset => emptyset_seqs
+  | lambda => lambda_seqs
+  | symbol y => symbol_seqs y
   | concat r1 r2 => concat_seqs {{r1}} {{r2}}
   | star r1 => star_seqs {{r1}}
   | nor r1 r2 => nor_seqs {{r1}} {{r2}}

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -48,22 +48,31 @@ Inductive nor_seqs (P Q: seqs): seqs :=
   .
 
 Inductive emptyset_seqs: seqs :=
-  (* | mk_emptyset: forall (s: seq),
-    False ->
-    emptyset_seqs s *)
   .
+  (* 
+  | mk_emptyset: forall (s: seq),
+    False ->
+    emptyset_seqs s
+  *)
 
 Inductive lambda_seqs: seqs :=
-  | mk_lambda: forall (s: seq),
+  | mk_lambda: lambda_seqs []
+  .
+  (*
+  | mk_lambda:
+    forall (s: seq),
     s = [] ->
     lambda_seqs s
-  .
+  *)
 
 Inductive symbol_seqs (a: alphabet): seqs :=
-  | mk_symbol: forall (s: seq),
+  | mk_symbol: symbol_seqs a [a].
+  (*
+  | mk_symbol:
+    forall (s: seq),
     s = [a] ->
     symbol_seqs a s
-  .
+  *)
 
 (* Here we use a mix of Fixpoint and Inductive predicates to define the denotation of regular expressions.
    This works, but it would be nicer to define it purely as an Inductive predicate.

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -3,6 +3,7 @@ Import ListNotations.
 
 Require Import CoqStock.Invs.
 Require Import CoqStock.Listerine.
+Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
@@ -114,7 +115,7 @@ Definition seqs_eq (s1 s2: seqs): Prop :=
 
 Notation "s1 {<->} s2" := (seqs_eq s1 s2) (at level 80).
 
-Theorem concat_emptyset_l: forall (r: seqs),
+Theorem concat_seqs_emptyset_l_is_emptyset: forall (r: seqs),
   concat_seqs emptyset_seqs r
   {<->}
   emptyset_seqs.
@@ -125,10 +126,20 @@ split.
   wreckit.
   invs L.
 - intros.
-  invs H. 
+  invs H.
 Qed.
 
-Theorem concat_emptyset_r: forall (r: seqs),
+Theorem concat_seqs_emptyset_l: forall (r: seqs) (s: seq),
+  s `notelem` concat_seqs emptyset_seqs r.
+Proof.
+intros.
+untie.
+invs H.
+wreckit.
+invs L.
+Qed.
+
+Theorem concat_seqs_emptyset_r_is_emptyset: forall (r: seqs),
   concat_seqs r emptyset_seqs
   {<->}
   emptyset_seqs.
@@ -142,7 +153,17 @@ split.
   invs H.
 Qed.
 
-Theorem concat_lambda_l: forall (r: seqs),
+Theorem concat_seqs_emptyset_r: forall (r: seqs) (s: seq),
+  s `notelem` concat_seqs r emptyset_seqs.
+Proof.
+intros.
+untie.
+invs H.
+wreckit.
+invs R.
+Qed.
+
+Theorem concat_seqs_lambda_l_is_l: forall (r: seqs),
   concat_seqs lambda_seqs r
   {<->}
   r.
@@ -165,7 +186,7 @@ split.
   + assumption.
 Qed.
 
-Theorem concat_lambda_r: forall (r: seqs),
+Theorem concat_seqs_lambda_r_is_r: forall (r: seqs),
   concat_seqs r lambda_seqs
   {<->}
   r.

--- a/src/CoqStock/Listerine.v
+++ b/src/CoqStock/Listerine.v
@@ -67,10 +67,27 @@ Local Ltac list_empty :=
   apply app_cons_not_nil
   (* [] = xs ++ y :: ys -> False *)
 | [ H: ?XS ++ ?YS = [] |- _ ] =>
-  apply app_eq_nil in H
+  let H0 := fresh "H0" in
+  let H1 := fresh "H1" in
+  apply app_eq_nil in H;
+  destruct H as [H0 H1];
+  try rewrite H0 in *;
+  try rewrite H1 in *
   (* xs ++ ys = [] -> 
         xs = [] 
      /\ ys = []
+  *)
+| [ H: [] = ?XS ++ ?YS |- _ ] =>
+  let H0 := fresh "H0" in
+  let H1 := fresh "H1" in
+  symmetry in H;
+  apply app_eq_nil in H;
+  destruct H as [H0 H1];
+  try rewrite H0 in *;
+  try rewrite H1 in *
+  (* [] = xs ++ ys -> 
+       xs = [] 
+    /\ ys = []
   *)
 | [ H: context [[] ++ _] |- _ ] =>
   rewrite app_nil_l in H
@@ -108,8 +125,7 @@ Example example_list_empty_eq_app: forall {A: Type} (xs: list A) (ys: list A),
 Proof.
 intros.
 list_empty.
-inversion H.
-assumption.
+reflexivity.
 Qed.
 
 Example example_list_empty_eq_app_easy: forall {A: Type} (xs: list A) (ys: list A),


### PR DESCRIPTION
  - Redefine Alphabet
  - Redefine some sequences as Inductive types to make hypothesis more readable and more theorems easily definable.  This includes:
    * emptyset_seqs
    * lambda_seqs
    * symbol_seqs
 - Define delta_def and prove it is equivalent to its predicate counterpart
 - Define derive and derive_def and start proving it is equivalent
 - Proof some simplification rules for sequences like:
     * concat lambda r = r
     * concat emptyset r = emptyset