### PR TITLE
Parametric Morphism for nor_seqs setoid

### DIFF
--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -350,40 +350,13 @@ Lemma commutes_a_nor: forall (p q: regex) (a: alphabet)
   {<->}
   {{ derive_def (nor p q) a }}.
 Proof.
-unfold "{<->}".
 intros.
-specialize IHp with s.
-specialize IHq with s.
-unfold "`elem`" in *.
+rewrite nor_seqs_distributes.
+rewrite IHp.
+rewrite IHq.
 dubstep derive_def.
-dubstep denote_regex.
-split.
-- intros.
-  apply nor_seqs_distributes in H.
-  invs H.
-  wreckit.
-  constructor.
-  unfold "`elem`" in *.
-  split; untie.
-  + apply L.
-    apply IHp.
-    assumption.
-  + apply R.
-    apply IHq.
-    assumption.
-- intros.
-  apply nor_seqs_distributes.
-  invs H.
-  wreckit.
-  unfold "`elem`" in *.
-  constructor.
-  split; untie.
-  + apply L.
-    apply IHp.
-    assumption.
-  + apply R.
-    apply IHq.
-    assumption.
+cbn.
+reflexivity.
 Qed.
 
 (* A helper Lemma for commutes_a_concat *)

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -219,8 +219,7 @@ split.
 Qed.
 
 (*
-The implementation of Setoid for seqs
-allows the use of rewrite and reflexivity.
+  The implementation of Setoid for seqs allows the use of rewrite and reflexivity.
 *)
 Example SeqsSetoidRewriteReflexivity: forall (r: seqs),
   concat_seqs emptyset_seqs r
@@ -233,8 +232,7 @@ reflexivity.
 Qed.
 
 (*
-The implementation not_seqs_morph
-allows the use of rewrite inside nor_seqs parameters.
+  The implementation of not_seqs_morph allows the use of rewrite inside nor_seqs parameters.
 *)
 Example NorSeqsMorphSetoidRewrite: forall (r s: seqs),
   nor_seqs (concat_seqs emptyset_seqs r) s


### PR DESCRIPTION
This allows to use the seqs setoid rewrite inside nor_seqs parameters.
This was used to make `commutes_a_nor` much closer to the proof mentioned by Brzozowski.