### PR TITLE
sequences are decidable

### DIFF
--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -22,6 +22,8 @@ Notation "p `notelem` P" := (~ (elem P p)) (at level 80).
 We are defining a set that is not necessarily computable.
 https://stackoverflow.com/questions/36588263/how-to-define-set-in-coq-without-defining-set-as-a-list-of-elements
 This axiom fixes that and allows us to prove double negation.
+This is similar to the axiom in Coq.Logic.Classical_Prop: https://coq.inria.fr/library/Coq.Logic.Classical_Prop.html
+`Axiom classic : forall P:Prop, P \/ ~ P.`
 *)
 Axiom seqs_dec:
   forall (s: seq) (R: seqs),


### PR DESCRIPTION
I was trying to prove things and ran into the following quite a lot
~ ~ P -> P
This is because `nor_seqs` uses `not` and all boolean operators are defined using `nor`.

I really like how we are defining sets, but I thought to double check that it was correct.
I found this post https://stackoverflow.com/questions/36588263/how-to-define-set-in-coq-without-defining-set-as-a-list-of-elements which felt quite definitive.

It seems out set is not computable, but that sounds wrong.
We know that a sequence will be in a set or not in a set.
I believe we want a computable set.

So I added the axiom
```coq
Axiom seqs_dec: forall (s: seq) (R: seqs),
  s `elem` R \/ s `notelem` R.
```
This way we gain the computability and don't have to swap it out for an inefficient set implementation that will make it harder to prove things too, according to the post.

Now it is easy to prove double negation.