### PR TITLE
Pair programming session 12: not an axiom

### DIFF
--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -135,28 +135,6 @@ split;
   assumption.
 Qed.
 
-Definition derive_step:
-  forall (r: regex) (a: alphabet) (s: seq)
-  , s `elem` derive_seqs_a {{ r }} a
-  -> (a :: s) `elem` {{ r }}.
-Proof.
-intros.
-unfold derive_seqs_a in H.
-assumption.
-Qed.
-
-Definition derive_step2:
-  forall (r: regex) (a: alphabet) (s: seq)
-  , s `elem` derive_seqs_a {{ r }} a
-  \/ s `notelem` derive_seqs_a {{ r }} a
-  -> (a :: s) `elem` {{ r }}
-  \/ (a :: s) `notelem` {{ r }}.
-Proof.
-intros.
-unfold derive_seqs_a in H.
-assumption.
-Qed.
-
 Theorem derive_seqs_step: forall (R: seqs) (a: alphabet) (s: seq),
   derive_seqs R (a :: s) {<->} derive_seqs (derive_seqs_a R a) s.
 Proof.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -135,6 +135,28 @@ split;
   assumption.
 Qed.
 
+Definition derive_step:
+  forall (r: regex) (a: alphabet) (s: seq)
+  , s `elem` derive_seqs_a {{ r }} a
+  -> (a :: s) `elem` {{ r }}.
+Proof.
+intros.
+unfold derive_seqs_a in H.
+assumption.
+Qed.
+
+Definition derive_step2:
+  forall (r: regex) (a: alphabet) (s: seq)
+  , s `elem` derive_seqs_a {{ r }} a
+  \/ s `notelem` derive_seqs_a {{ r }} a
+  -> (a :: s) `elem` {{ r }}
+  \/ (a :: s) `notelem` {{ r }}.
+Proof.
+intros.
+unfold derive_seqs_a in H.
+assumption.
+Qed.
+
 Theorem derive_seqs_step: forall (R: seqs) (a: alphabet) (s: seq),
   derive_seqs R (a :: s) {<->} derive_seqs (derive_seqs_a R a) s.
 Proof.
@@ -310,19 +332,19 @@ Qed.
 
 (*
   Let us consider now (3.8).
-  It is sufficient to prove this relation for $f(P, Q) = P + Q$ and 
+  It is sufficient to prove this relation for $f(P, Q) = P + Q$ and
   for $f(P, Q) = P'$, for this is a complete set of Boolean connectives.
   Now
 
   $$
   \begin{aligned}
-  D_a (P + Q) &= \{t | a.t \in (P + Q)\} \\
-              &= \{u | a.u \in P\} + \{v | a.v \in P\} \\
-              &= D_a P + D_a Q. \\
+  D_a (P + Q) &= {t | a.t \in (P + Q)}
+              &= {u | a.u \in P} + {v | a.v \in P}
+              &= D_a P + D_a Q.
   \end{aligned}
   $$
 
-  It is clear that this rule can be extended to any number of regular expressions, 
+  It is clear that this rule can be extended to any number of regular expressions,
   i.e. that $D_a (R_1 + R_2 + \ldots) = D_a R_1 + D_a R_2 + \ldots$
   even when the number of $R_j$ is countably infinite.
   Next, note that $a.D_a R + a.D_a R' = a.I$.
@@ -460,20 +482,40 @@ split.
 Qed.
 
 (*
-  Next consider $D_a P.Q$ . Let $P = \delta(P) + P_0$, where $\delta(P_0) = \emptyset$.
-  Then
+  Next consider:
+  derive_seqs_a (R: seqs) (a: alphabet) (t: seq): Prop :=
+  (a :: t) `elem` R.
+  derive_seqs_a (concat_seqs P Q)
+  Let:
+  P = delta_def(P) or P_0
+  where delta_def(P_0) = emptyset
+  Then:
+  derive_seqs_a (concat_seqs P Q) a
+    {<->} {s | (a :: s) `elem` (concat_seqs P Q)}
+    {<->} {s | (a :: s) `elem` (concat_seqs (or_seqs {{delta_def(P)}} P_0) Q)}
+    {<->} {u | (a :: u) `elem` (concat_seqs {{delta_def(P)}} Q)}
+          \/
+          {v | (a :: v) `elem` (concat_seqs P_0 Q)}
+    {<->} concat_seqs {{delta_def(P)}} (derive_seqs_a Q a)
+          \/
+          {v_1 ++ v_2 | (a :: v_1) `elem` P_0, v_2 `elem` Q}
+    {<->} concat_seqs {{delta_def(P)}} (derive_seqs_a Q a)
+          \/
+          concat_seqs ({v_1 | (a :: v_1) `elem` P_0}) Q
+    {<->} concat_seqs {{delta_def(P)}} (derive_seqs_a Q a)
+          \/
+          concat_seqs (derive_seqs_a P_0 a) Q.
 
-  $$
-  \begin{aligned}
-  D_a PQ  &= \{s | as \in (\delta(P) + P_0)Q\} \\
-          &= \{u | au \in \delta(P)Q\} + \{v | av \in P_0 Q\} \\
-          &= \delta(P) (D_a Q) + \{v_1 v_2 | a v_1 \in P_0, v_2 \in Q\} \\
-          &= \delta(P) (D_a Q) + \{v_1 | a v_1 \in P_0\} Q \\
-          &= \delta(P) (D_a Q) + (D_a P_0) Q. \\
-  \end{aligned}
-  $$
-
-  But $D_a P = D_a (P_0 + \lambda) = D_a P_0$; hence $D_a (PQ) = \delta(P) D_a Q + (D_a P) Q$,
+  But:
+  derive_seqs_a P a
+  {<->} derive_seqs_a (or_seqs P_0 lambda_seqs) a
+  {<->} derive_seqs_a P_0 a
+  ; hence:
+  derive_seqs_a (concat_seqs P Q)
+  {<->} concat_seqs {{delta_def(P)}} (derive_seqs_a Q a)
+        \/
+        concat_seqs (derive_seqs_a P a) Q
+        concat_seqs ((a :: s) \in P) Q
   which is rule (3.7).
 *)
 Lemma commutes_a_concat: forall (a : alphabet) (p q: regex)

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -240,7 +240,48 @@ intros.
 untie.
 Qed.
 
-Theorem denotation_nor_is_decidable (p q: regex) (s: seq):
+Lemma denotation_emptyset_is_decidable (s: seq):
+  s `elem` {{ emptyset }} \/ s `notelem` {{ emptyset }}.
+Proof.
+right.
+apply notelem_emptyset.
+Qed.
+
+Lemma denotation_lambda_is_decidable (s: seq):
+  s `elem` {{ lambda }} \/ s `notelem` {{ lambda }}.
+Proof.
+destruct s.
+- left. constructor.
+- right. untie. invs H.
+Qed.
+
+Lemma denotation_symbol_is_decidable (s: seq) (a: alphabet):
+  s `elem` {{ symbol a }} \/ s `notelem` {{ symbol a }}.
+Proof.
+destruct s.
+- right. untie. invs H.
+- destruct a, a0.
+  + destruct s.
+    * left.
+      constructor.
+    * right.
+      untie.
+      invs H.
+  + right.
+    untie.
+    invs H.
+  + right.
+    untie.
+    invs H.
+  + destruct s.
+    * left.
+      constructor.
+    * right.
+      untie.
+      invs H.
+Qed.
+
+Lemma denotation_nor_is_decidable (p q: regex) (s: seq):
   s `elem` {{ p }} \/ s `notelem` {{ p }} ->
   s `elem` {{ q }} \/ s `notelem` {{ q }} ->
   s `elem` {{ nor p q }} \/ s `notelem` {{ nor p q }}.
@@ -270,46 +311,59 @@ wreckit.
   * assumption.
 Qed.
 
+Lemma denotation_concat_is_decidable_for_empty_string (p q: regex):
+  [] `elem` {{ p }} \/ [] `notelem` {{ p }} ->
+  [] `elem` {{ q }} \/ [] `notelem` {{ q }} ->
+  [] `elem` {{ concat p q }} \/ [] `notelem` {{ concat p q }}.
+Proof.
+intros.
+wreckit.
+- left.
+  constructor.
+  exists [].
+  exists [].
+  exists eq_refl.
+  wreckit; assumption.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  listerine.
+  contradiction.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  listerine.
+  contradiction.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  listerine.
+  contradiction.
+Qed.
+
+Lemma denotation_star_is_decidable_for_empty_string (r: regex):
+  [] `elem` {{ star r }} \/ [] `notelem` {{ star r }}.
+Proof.
+left.
+constructor.
+reflexivity.
+Qed.
+
 Theorem denotation_is_decidable_on_empty_string (r: regex):
   [] `elem` {{ r }} \/ [] `notelem` {{ r }}.
 Proof.
 intros.
 induction r.
-- right.
-  apply notelem_emptyset.
-- left.
-  constructor.
-- right.
-  untie.
-  invs H.
-- wreckit.
-  + left.
-    constructor.
-    exists [].
-    exists [].
-    exists eq_refl.
-    wreckit; assumption.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    listerine.
-    contradiction.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    listerine.
-    contradiction.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    listerine.
-    contradiction.
-- left.
-  constructor.
-  reflexivity.
+- apply denotation_emptyset_is_decidable.
+- apply denotation_lambda_is_decidable.
+- apply denotation_symbol_is_decidable.
+- apply denotation_concat_is_decidable_for_empty_string.
+  + assumption.
+  + assumption.
+- apply denotation_star_is_decidable_for_empty_string.
 - apply denotation_nor_is_decidable.
   + assumption.
   + assumption.
@@ -321,150 +375,32 @@ Proof.
 induction s.
 - apply denotation_is_decidable_on_empty_string.
 - induction r.
-  + admit.
-  + admit.
-  + admit.
+  + apply denotation_emptyset_is_decidable.
+  + apply denotation_lambda_is_decidable.
+  + apply denotation_symbol_is_decidable.
   + wreckit.
-    invs B.
-    wreckit.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-intros.
-induction r.
-- right.
-  apply notelem_emptyset.
-- destruct s.
-  + left.
-    constructor.
-  + right.
-    untie.
-    invs H.
-- destruct s.
-  + right.
-    untie.
-    invs H.
-  + destruct a, a0.
-    * destruct s.
-      --- left.
-          constructor.
-      --- right.
-          untie.
-          invs H.
-    * right.
-      untie.
-      invs H.
-    * right.
-      untie.
-      invs H.
-    * destruct s.
-      --- left.
-          constructor.
-      --- right.
-          untie.
-          invs H.
-- induction s.
-  + wreckit.
-    * left.
-      constructor.
-      exists [].
-      exists [].
-      exists eq_refl.
-      wreckit; assumption.
-    * right.
-      untie.
-      invs H.
+    * invs B.
       wreckit.
-      listerine.
-      contradiction.
-    * right.
-      untie.
-      invs H.
-      wreckit.
-      listerine.
-      contradiction.
-    * right.
-      untie.
-      invs H.
-      wreckit.
-      listerine.
-      contradiction.
-  + simpl.
-    left.
-    * constructor.
-
-
-        concat s t =
-          or (concat (derive_def s a) t)
-             (concat (delta_def s) (derive_def t a))
-          (* if nullabe s *)
-        concat s t =
-          or (concat (derive_def s a) t)
-             (derive_def t a)
-          (* else if not nullable s *)
-        concat s t =
-          concat (derive_def s a) t
-
-
-    listerine.
-- admit.
-- simpl.
-  wreckit.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    contradiction.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    contradiction.
-  + right.
-    untie.
-    invs H.
-    wreckit.
-    contradiction.
-  + left.
-    constructor.
-    wreckit.
-    * assumption.
-    * assumption.
-Qed.
-
-
-
-
-Admitted.
+(* TODO: Help Wanted *)
+Abort.
 
 Definition not_seqs (R: seqs) : seqs :=
   nor_seqs R R.
 
-Theorem double_neg_implies:
+Theorem double_negation:
   forall (r: regex) (s: seq),
   ((~ ~ (s `elem` {{ r }})) -> (s `elem` {{ r }})).
 Proof.
   intros.
-  specialize (denotation_is_decidable r s).
-  intros.
+  assert (s `elem` {{ r }} \/ s `notelem` {{ r }}).
+  - admit. (* TODO: apply denotation_is_decidable *)
+  - intros.
   unfold not in *.
   destruct H0 as [x | not_x].
-  - exact x.
-  - apply H in not_x.
+  + exact x.
+  + apply H in not_x.
     induction not_x.
-Qed.
+Abort.
 
 Theorem not_seqs_not_seqs: forall (r: regex),
   not_seqs (not_seqs {{r}})
@@ -472,8 +408,11 @@ Theorem not_seqs_not_seqs: forall (r: regex),
   {{r}}.
 Proof.
 intros.
-split; specialize (denotation_is_decidable r s); intros.
-- wreckit.
+split.
+- assert (s `elem` {{ r }} \/ s `notelem` {{ r }}).
+  admit. (* TODO: apply denotation_is_decidable *)
+  intros.
+  wreckit.
   + assumption.
   + invs H0.
     wreckit.
@@ -483,7 +422,10 @@ split; specialize (denotation_is_decidable r s); intros.
     constructor.
     wreckit.
     assumption.
-- constructor.
+- assert (s `elem` {{ r }} \/ s `notelem` {{ r }}).
+  admit. (* TODO: apply denotation_is_decidable *)
+  intros.
+  constructor.
   wreckit.
   + unfold not.
     intros.
@@ -491,7 +433,7 @@ split; specialize (denotation_is_decidable r s); intros.
     wreckit.
     contradiction.
   + contradiction.
-Qed.
+Abort.
 
 Theorem concat_seqs_emptyset_l_is_emptyset: forall (r: seqs),
   concat_seqs emptyset_seqs r

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -228,11 +228,6 @@ Fixpoint denote_regex (r: regex): seqs :=
   end
 where "{{ r }}" := (denote_regex r).
 
-(* Definition seq_nullable (r: regex):
-  [] `elem` {{ delta_def r }} \/
-  forall (s: seq), s `notelem` {{ delta_def r }}.
-Admitted. *)
-
 Theorem notelem_emptyset: forall (s: seq),
   s `notelem` emptyset_seqs.
 Proof.
@@ -352,7 +347,7 @@ constructor.
 reflexivity.
 Qed.
 
-Theorem denotation_is_decidable_on_empty_string (r: regex):
+Lemma denotation_is_decidable_on_empty_string (r: regex):
   [] `elem` {{ r }} \/ [] `notelem` {{ r }}.
 Proof.
 intros.
@@ -387,7 +382,7 @@ Abort.
 Definition not_seqs (R: seqs) : seqs :=
   nor_seqs R R.
 
-Theorem double_negation:
+Theorem not_not_regex_is_regex:
   forall (r: regex) (s: seq),
   ((~ ~ (s `elem` {{ r }})) -> (s `elem` {{ r }})).
 Proof.
@@ -402,7 +397,7 @@ Proof.
     induction not_x.
 Abort.
 
-Theorem not_seqs_not_seqs: forall (r: regex),
+Theorem not_seqs_not_seqs_is_seqs: forall (r: regex),
   not_seqs (not_seqs {{r}})
   {<->}
   {{r}}.

--- a/src/Brzozowski/Sequences.v
+++ b/src/Brzozowski/Sequences.v
@@ -228,11 +228,269 @@ Fixpoint denote_regex (r: regex): seqs :=
   end
 where "{{ r }}" := (denote_regex r).
 
+(* Definition seq_nullable (r: regex):
+  [] `elem` {{ delta_def r }} \/
+  forall (s: seq), s `notelem` {{ delta_def r }}.
+Admitted. *)
+
 Theorem notelem_emptyset: forall (s: seq),
   s `notelem` emptyset_seqs.
 Proof.
 intros.
 untie.
+Qed.
+
+Theorem denotation_nor_is_decidable (p q: regex) (s: seq):
+  s `elem` {{ p }} \/ s `notelem` {{ p }} ->
+  s `elem` {{ q }} \/ s `notelem` {{ q }} ->
+  s `elem` {{ nor p q }} \/ s `notelem` {{ nor p q }}.
+Proof.
+simpl.
+intros.
+wreckit.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  contradiction.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  contradiction.
+- right.
+  untie.
+  invs H.
+  wreckit.
+  contradiction.
+- left.
+  constructor.
+  wreckit.
+  * assumption.
+  * assumption.
+Qed.
+
+Theorem denotation_is_decidable_on_empty_string (r: regex):
+  [] `elem` {{ r }} \/ [] `notelem` {{ r }}.
+Proof.
+intros.
+induction r.
+- right.
+  apply notelem_emptyset.
+- left.
+  constructor.
+- right.
+  untie.
+  invs H.
+- wreckit.
+  + left.
+    constructor.
+    exists [].
+    exists [].
+    exists eq_refl.
+    wreckit; assumption.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    listerine.
+    contradiction.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    listerine.
+    contradiction.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    listerine.
+    contradiction.
+- left.
+  constructor.
+  reflexivity.
+- apply denotation_nor_is_decidable.
+  + assumption.
+  + assumption.
+Qed.
+
+Theorem denotation_is_decidable (r: regex) (s: seq):
+  s `elem` {{ r }} \/ s `notelem` {{ r }}.
+Proof.
+induction s.
+- apply denotation_is_decidable_on_empty_string.
+- induction r.
+  + admit.
+  + admit.
+  + admit.
+  + wreckit.
+    invs B.
+    wreckit.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+intros.
+induction r.
+- right.
+  apply notelem_emptyset.
+- destruct s.
+  + left.
+    constructor.
+  + right.
+    untie.
+    invs H.
+- destruct s.
+  + right.
+    untie.
+    invs H.
+  + destruct a, a0.
+    * destruct s.
+      --- left.
+          constructor.
+      --- right.
+          untie.
+          invs H.
+    * right.
+      untie.
+      invs H.
+    * right.
+      untie.
+      invs H.
+    * destruct s.
+      --- left.
+          constructor.
+      --- right.
+          untie.
+          invs H.
+- induction s.
+  + wreckit.
+    * left.
+      constructor.
+      exists [].
+      exists [].
+      exists eq_refl.
+      wreckit; assumption.
+    * right.
+      untie.
+      invs H.
+      wreckit.
+      listerine.
+      contradiction.
+    * right.
+      untie.
+      invs H.
+      wreckit.
+      listerine.
+      contradiction.
+    * right.
+      untie.
+      invs H.
+      wreckit.
+      listerine.
+      contradiction.
+  + simpl.
+    left.
+    * constructor.
+
+
+        concat s t =
+          or (concat (derive_def s a) t)
+             (concat (delta_def s) (derive_def t a))
+          (* if nullabe s *)
+        concat s t =
+          or (concat (derive_def s a) t)
+             (derive_def t a)
+          (* else if not nullable s *)
+        concat s t =
+          concat (derive_def s a) t
+
+
+    listerine.
+- admit.
+- simpl.
+  wreckit.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    contradiction.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    contradiction.
+  + right.
+    untie.
+    invs H.
+    wreckit.
+    contradiction.
+  + left.
+    constructor.
+    wreckit.
+    * assumption.
+    * assumption.
+Qed.
+
+
+
+
+Admitted.
+
+Definition not_seqs (R: seqs) : seqs :=
+  nor_seqs R R.
+
+Theorem double_neg_implies:
+  forall (r: regex) (s: seq),
+  ((~ ~ (s `elem` {{ r }})) -> (s `elem` {{ r }})).
+Proof.
+  intros.
+  specialize (denotation_is_decidable r s).
+  intros.
+  unfold not in *.
+  destruct H0 as [x | not_x].
+  - exact x.
+  - apply H in not_x.
+    induction not_x.
+Qed.
+
+Theorem not_seqs_not_seqs: forall (r: regex),
+  not_seqs (not_seqs {{r}})
+  {<->}
+  {{r}}.
+Proof.
+intros.
+split; specialize (denotation_is_decidable r s); intros.
+- wreckit.
+  + assumption.
+  + invs H0.
+    wreckit.
+    unfold not in L.
+    exfalso.
+    apply L.
+    constructor.
+    wreckit.
+    assumption.
+- constructor.
+  wreckit.
+  + unfold not.
+    intros.
+    invs H.
+    wreckit.
+    contradiction.
+  + contradiction.
 Qed.
 
 Theorem concat_seqs_emptyset_l_is_emptyset: forall (r: seqs),


### PR DESCRIPTION
Here we try to prove
```
Theorem denotation_is_decidable (r: regex) (s: seq):
  s `elem` {{ r }} \/ s `notelem` {{ r }}.
```
instead of adding an axiom, which is proposed in https://github.com/awalterschulze/regex-reexamined-coq/pull/108
We still have to prove denotation is decidable for concat and star, but it is already proven for all others, including the important `nor`.

Given this Theorem it is possible to prove double negation in these contexts:
```
Theorem not_not_regex_is_regex:
  forall (r: regex) (s: seq),
  ((~ ~ (s `elem` {{ r }})) -> (s `elem` {{ r }})).
```
and
```
Theorem not_seqs_not_seqs_is_seqs: forall (r: regex),
  not_seqs (not_seqs {{r}})
  {<->}
  {{r}}.
```
We hope that this should be enough and that we can finish this proof and not introduce an axiom.