### PR TITLE
Started renaming elem to \in

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -37,6 +37,7 @@ src/Brzozowski/Boolean.v
 src/Brzozowski/Decidable.v
 src/Brzozowski/Delta.v
 src/Brzozowski/Derive.v
+src/Brzozowski/ExampleR.v
 src/Brzozowski/Language.v
 src/Brzozowski/Regex.v
 src/Brzozowski/Simplify.v

--- a/src/Brzozowski/Boolean.v
+++ b/src/Brzozowski/Boolean.v
@@ -10,9 +10,9 @@ Require Import Brzozowski.Language.
 
 (* the *intersection* $P \& Q$, *)
 Theorem elem_intersection: forall (p q: regex) (s: str),
-  s `elem` {{p}} ->
-  s `elem` {{q}} ->
-  s `elem` {{and p q}}.
+  s \in {{p}} ->
+  s \in {{q}} ->
+  s \in {{and p q}}.
 Proof.
 intros.
 cbn.
@@ -29,8 +29,8 @@ constructor.
 Qed.
 
 Theorem elem_union_l: forall (p q: regex) (s: str),
-  s `elem` {{p}} ->
-  s `elem` {{or p q}}.
+  s \in {{p}} ->
+  s \in {{or p q}}.
 Proof.
 intros.
 cbn.
@@ -53,15 +53,15 @@ constructor.
 Qed.
 
 Theorem elem_union_r: forall (p q: regex) (s: str),
-  s `elem` {{q}} ->
-  s `elem` {{or p q}}.
+  s \in {{q}} ->
+  s \in {{or p q}}.
 Proof.
 (* TODO: Good First Issue *)
 Abort.
 
 Theorem elem_complement: forall (p: regex) (s: str),
-  s `notelem` {{p}} ->
-  s `elem` {{complement p}}.
+  s \notin {{p}} ->
+  s \in {{complement p}}.
 Proof.
 unfold not.
 intros.
@@ -73,8 +73,8 @@ assumption.
 Qed.
 
 Theorem notelem_complement: forall (p: regex) (s: str),
-  s `elem` {{p}} ->
-  s `notelem` {{complement p}}.
+  s \in {{p}} ->
+  s \notin {{complement p}}.
 Proof.
 unfold not.
 intros.
@@ -85,20 +85,19 @@ contradiction.
 Qed.
 
 Theorem elem_complement_emptyset: forall (s: str),
-  s `elem` {{complement emptyset}}.
+  s \in {{complement emptyset}}.
 Proof.
 intros.
 cbn.
 constructor.
 wreckit.
 unfold not.
-unfold "`elem`".
 intros.
 inversion H.
 Qed.
 
 Theorem notelem_emptyset: forall (s: str),
-  s `notelem` {{emptyset}}.
+  s \notin {{emptyset}}.
 Proof.
 intros.
 unfold not.
@@ -108,8 +107,8 @@ inversion H.
 Qed.
 
 Theorem notelem_intersection_l: forall (p q: regex) (s: str),
-  s `notelem` {{p}} ->
-  s `notelem` {{and p q}}.
+  s \notin {{p}} ->
+  s \notin {{and p q}}.
 Proof.
 unfold not.
 intros.
@@ -126,8 +125,8 @@ assumption.
 Qed.
 
 Theorem notelem_intersection_r: forall (p q: regex) (s: str),
-    s `notelem` {{q}} ->
-    s `notelem` {{and p q}}.
+    s \notin {{q}} ->
+    s \notin {{and p q}}.
 Proof.
 unfold not.
 intros.
@@ -146,9 +145,9 @@ assumption.
 Qed.
 
 Theorem notelem_union: forall (p q: regex) (s: str),
-    s `notelem` {{p}} ->
-    s `notelem` {{q}}->
-    s `notelem` {{or p q}}.
+    s \notin {{p}} ->
+    s \notin {{q}}->
+    s \notin {{or p q}}.
 Proof.
 unfold not.
 intros.
@@ -164,7 +163,7 @@ constructor; assumption.
 Qed.
 
 Lemma elem_or_notelem_symbol: forall (a: alphabet) (s: str),
-  s `elem` {{symbol a}} \/ s `notelem` {{symbol a}}.
+  s \in {{symbol a}} \/ s \notin {{symbol a}}.
 Proof.
 induction s.
 - right.
@@ -181,10 +180,10 @@ induction s.
     unfold not.
     intros.
     inversion H.
-Qed.   
+Qed.
 
 Lemma elem_or_notelem_emptyset: forall (s: str),
-  s `elem` {{emptyset}} \/ s `notelem` {{emptyset}}.
+  s \in {{emptyset}} \/ s \notin {{emptyset}}.
 Proof.
 intros.
 right.
@@ -194,7 +193,7 @@ inversion H.
 Qed.
 
 Lemma elem_or_notelem_lambda: forall (s: str),
-  s `elem` {{lambda}} \/ s `notelem` {{lambda}}.
+  s \in {{lambda}} \/ s \notin {{lambda}}.
 Proof.
 intros.
 induction s.
@@ -203,25 +202,25 @@ induction s.
 Qed.
 
 Lemma elem_or_notelem_concat: forall (r1 r2: regex) (s: str),
-  s `elem` {{concat r1 r2}} \/ s `notelem` {{concat r1 r2}}.
+  s \in {{concat r1 r2}} \/ s \notin {{concat r1 r2}}.
 Proof.
 (* TODO: Help Wanted *)
 Abort.
 
 Lemma elem_or_notelem_star: forall (r: regex) (s: str),
-  s `elem` {{star r}} \/ s `notelem` {{star r}}.
+  s \in {{star r}} \/ s \notin {{star r}}.
 Proof.
 (* TODO: Help Wanted *)
 Abort.
 
 Lemma elem_or_notelem_nor: forall (r1 r2: regex) (s: str),
-  s `elem` {{nor r1 r2}} \/ s `notelem` {{nor r1 r2}}.
+  s \in {{nor r1 r2}} \/ s \notin {{nor r1 r2}}.
 Proof.
 (* TODO: Help Wanted *)
 Abort.
 
 Theorem elem_or_notelem : forall (r: regex) (s: str),
-    s `elem` {{r}} \/ s `notelem` {{r}}.
+    s \in {{r}} \/ s \notin {{r}}.
 Proof.
 induction r.
 - apply elem_or_notelem_emptyset.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -15,7 +15,7 @@ Require Import Brzozowski.Regex.
 Require Import Lia.
 
 Definition regex_is_decidable (r: regex) :=
-    (forall s: str, s `elem` {{r}} \/ s `notelem` {{r}}).
+    (forall s: str, s \in {{r}} \/ s \notin {{r}}).
 
 (* TODO: move into listerine *)
 Lemma length_zero_string_is_empty (s : str) :
@@ -79,11 +79,11 @@ Lemma denotation_concat_is_decidable_helper (p q: regex):
           s = s1 ++ s2 ->
           length s1 <= n ->
           (* does not match concat pairwise *)
-          ((s1 `notelem` {{ p }} \/ s2 `notelem` {{ q }})))
+          ((s1 \notin {{ p }} \/ s2 \notin {{ q }})))
       \/ (exists (s1 s2: str),
             s = s1 ++ s2 /\
             length s1 <= n /\
-            (s1 `elem` {{ p }} /\ s2 `elem` {{ q }}))).
+            (s1 \in {{ p }} /\ s2 \in {{ q }}))).
 Proof.
   intros Hdecp Hdecq s n.
   induction n.
@@ -190,9 +190,9 @@ Qed.
 
 (s : str)
 
-s `elem` (concat p q)
+s \in (concat p q)
 or not
-s `elem` (concat p q)
+s \in (concat p q)
 
 
 
@@ -232,14 +232,14 @@ Proof.
 Qed.
 
 Lemma denotation_emptyset_is_decidable (s: str):
-  s `elem` {{ emptyset }} \/ s `notelem` {{ emptyset }}.
+  s \in {{ emptyset }} \/ s \notin {{ emptyset }}.
 Proof.
 right.
-apply notelem_emptyset.
+apply notin_emptyset.
 Qed.
 
 Lemma denotation_lambda_is_decidable (s: str):
-  s `elem` {{ lambda }} \/ s `notelem` {{ lambda }}.
+  s \in {{ lambda }} \/ s \notin {{ lambda }}.
 Proof.
 destruct s.
 - left. constructor.
@@ -247,7 +247,7 @@ destruct s.
 Qed.
 
 Lemma denotation_symbol_is_decidable (s: str) (a: alphabet):
-  s `elem` {{ symbol a }} \/ s `notelem` {{ symbol a }}.
+  s \in {{ symbol a }} \/ s \notin {{ symbol a }}.
 Proof.
 destruct s.
 - right. untie. invs H.
@@ -273,9 +273,9 @@ destruct s.
 Qed.
 
 Lemma denotation_nor_is_decidable (p q: regex) (s: str):
-  s `elem` {{ p }} \/ s `notelem` {{ p }} ->
-  s `elem` {{ q }} \/ s `notelem` {{ q }} ->
-  s `elem` {{ nor p q }} \/ s `notelem` {{ nor p q }}.
+  s \in {{ p }} \/ s \notin {{ p }} ->
+  s \in {{ q }} \/ s \notin {{ q }} ->
+  s \in {{ nor p q }} \/ s \notin {{ nor p q }}.
 Proof.
 simpl.
 intros.
@@ -303,9 +303,9 @@ wreckit.
 Qed.
 
 Lemma denotation_concat_is_decidable_for_empty_string (p q: regex):
-  [] `elem` {{ p }} \/ [] `notelem` {{ p }} ->
-  [] `elem` {{ q }} \/ [] `notelem` {{ q }} ->
-  [] `elem` {{ concat p q }} \/ [] `notelem` {{ concat p q }}.
+  [] \in {{ p }} \/ [] \notin {{ p }} ->
+  [] \in {{ q }} \/ [] \notin {{ q }} ->
+  [] \in {{ concat p q }} \/ [] \notin {{ concat p q }}.
 Proof.
 intros.
 wreckit.
@@ -337,7 +337,7 @@ Qed.
 
 
 Lemma denotation_star_is_decidable_for_empty_string (r: regex):
-  [] `elem` {{ star r }} \/ [] `notelem` {{ star r }}.
+  [] \in {{ star r }} \/ [] \notin {{ star r }}.
 Proof.
 left.
 constructor.
@@ -348,17 +348,17 @@ Lemma denotation_star_is_decidable_helper (r: regex) (k: nat) (s: str) (a: alpha
   regex_is_decidable r ->
   (forall (s': str),
       length s' < length (a::s) -> (
-        s' `elem` {{star r}}
-           \/ s' `notelem` {{star r}})) ->
+        s' \in {{star r}}
+           \/ s' \notin {{star r}})) ->
       (forall (s1 s2: str),
           length s1 <= k ->
           (a::s) = a::s1 ++ s2 ->
           (* does not match concat pairwise *)
-          ((a::s1 `notelem` {{ r }} \/ s2 `notelem` {{ star r }})))
+          ((a::s1 \notin {{ r }} \/ s2 \notin {{ star r }})))
       \/ (exists (s1 s2: str),
             length s1 <= k /\
             (a::s) = a::s1 ++ s2 /\
-            (a::s1 `elem` {{ r }} /\ s2 `elem` {{ star r }})).
+            (a::s1 \in {{ r }} /\ s2 \in {{ star r }})).
 Proof.
   intro Hdecr.
   intro Hdecstarr.
@@ -455,8 +455,8 @@ Lemma denotation_star_is_decidable_for_small_strings (r: regex) (n: nat):
   -> (forall (s: str),
         length s <= n
         ->
-        (s `elem` {{star r}}
-            \/ s `notelem` {{star r}})).
+        (s \in {{star r}}
+            \/ s \notin {{star r}})).
 Proof.
   intro Hdec.
   induction n.
@@ -476,7 +476,7 @@ Proof.
             inversion H.
             +++ discriminate.
             +++ invs H0.
-                wreckit. 
+                wreckit.
 
 
 
@@ -529,7 +529,7 @@ for our idea on how to prove this. *)
 Abort.
 
 Lemma denotation_is_decidable_on_empty_string (r: regex):
-  [] `elem` {{ r }} \/ [] `notelem` {{ r }}.
+  [] \in {{ r }} \/ [] \notin {{ r }}.
 Proof.
 intros.
 induction r.
@@ -546,7 +546,7 @@ induction r.
 Qed.
 
 Theorem denotation_is_decidable (r: regex) (s: str):
-  s `elem` {{ r }} \/ s `notelem` {{ r }}.
+  s \in {{ r }} \/ s \notin {{ r }}.
 Proof.
 generalize dependent s.
 induction r.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -25,10 +25,10 @@ Require Import Brzozowski.Language.
 
 Inductive delta: regex -> regex -> Prop :=
   | delta_lambda (r: regex):
-    [] `elem` {{r}} ->
+    [] \in {{r}} ->
     delta r lambda
   | delta_emptyset (r: regex):
-    [] `notelem` {{r}} ->
+    [] \notin {{r}} ->
     delta r emptyset
     .
 

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -19,7 +19,7 @@ the derivative of $R$ with respect to $s$ is denoted by $D_s R$ and is
 $D_s R = \{t | s.t \in R \}$.
 *)
 Definition derive_lang (R: lang) (s: str) (t: str): Prop :=
-  (s ++ t) `elem` R.
+  (s ++ t) \in R.
 
 (* Part of THEOREM 3.2
    For completeness, if s = \lambda, then D_[] R = R
@@ -30,10 +30,8 @@ Proof.
 intros.
 unfold derive_lang.
 cbn.
-unfold "`elem`".
 unfold "{<->}".
 intros.
-unfold "`elem`".
 easy.
 Qed.
 
@@ -61,12 +59,12 @@ Proof.
 intros.
 split.
 - unfold derive_lang.
-  unfold "`elem`".
+
   intros.
   rewrite app_assoc.
   assumption.
 - unfold derive_lang.
-  unfold "`elem`".
+
   intros.
   rewrite app_assoc in H.
   assumption.
@@ -80,12 +78,12 @@ Proof.
 intros.
 split.
 - unfold derive_lang.
-  unfold "`elem`".
+
   intros.
   cbn in *.
   assumption.
 - unfold derive_lang.
-  unfold "`elem`".
+
   intros.
   cbn in *.
   assumption.
@@ -95,7 +93,7 @@ Qed.
 D_a R = { t | a.t \in R}
 *)
 Definition derive_lang_a (R: lang) (a: alphabet) (t: str): Prop :=
-  (a :: t) `elem` R.
+  (a :: t) \in R.
 
 Theorem derive_lang_a_single: forall (R: lang) (a: alphabet),
   derive_lang R [a] {<->} derive_lang_a R a.
@@ -110,27 +108,25 @@ easy.
 Qed.
 
 Theorem derive_lang_single: forall (R: lang) (a: alphabet) (s s0: str),
-  s0 `elem` derive_lang R (a :: s) <->
-  (s ++ s0) `elem` derive_lang R (a :: []).
+  s0 \in derive_lang R (a :: s) <->
+  (s ++ s0) \in derive_lang R (a :: []).
 Proof.
 intros.
 split;
   intros;
   unfold derive_lang in *;
-  unfold "`elem`" in *;
   listerine;
   assumption.
 Qed.
 
 Theorem derive_lang_double: forall (R: lang) (a a0: alphabet) (s s0: str),
-  s0 `elem` derive_lang R (a :: a0 :: s) <->
-  (s ++ s0) `elem` derive_lang R (a :: a0 :: []).
+  s0 \in derive_lang R (a :: a0 :: s) <->
+  (s ++ s0) \in derive_lang R (a :: a0 :: []).
 Proof.
 intros.
 split;
   intros;
   unfold derive_lang in *;
-  unfold "`elem`" in *;
   listerine;
   assumption.
 Qed.
@@ -142,7 +138,6 @@ intros.
 unfold derive_lang.
 unfold derive_lang_a.
 unfold "{<->}".
-unfold "`elem`".
 intros.
 listerine.
 easy.
@@ -151,8 +146,8 @@ Qed.
 (* Alternative inductive predicate for derive_lang *)
 Inductive derive_lang_a' (R: lang) (a: alphabet) (t: str): Prop :=
   | mk_derive_lang:
-    (a :: t) `elem` R ->
-    t `elem` (derive_lang_a' R a)
+    (a :: t) \in R ->
+    t \in (derive_lang_a' R a)
   .
 
 Theorem derive_lang_a_star_a:
@@ -444,24 +439,24 @@ Qed.
 (*
   Next consider:
   derive_lang_a (R: lang) (a: alphabet) (t: str): Prop :=
-  (a :: t) `elem` R.
+  (a :: t) \in R.
   derive_lang_a (concat_lang P Q)
   Let:
   P = delta_def(P) or P_0
   where delta_def(P_0) = emptyset
   Then:
   derive_lang_a (concat_lang P Q) a
-    {<->} {s | (a :: s) `elem` (concat_lang P Q)}
-    {<->} {s | (a :: s) `elem` (concat_lang (or_lang {{delta_def(P)}} P_0) Q)}
-    {<->} {u | (a :: u) `elem` (concat_lang {{delta_def(P)}} Q)}
+    {<->} {s | (a :: s) \in (concat_lang P Q)}
+    {<->} {s | (a :: s) \in (concat_lang (or_lang {{delta_def(P)}} P_0) Q)}
+    {<->} {u | (a :: u) \in (concat_lang {{delta_def(P)}} Q)}
           \/
-          {v | (a :: v) `elem` (concat_lang P_0 Q)}
+          {v | (a :: v) \in (concat_lang P_0 Q)}
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
-          {v_1 ++ v_2 | (a :: v_1) `elem` P_0, v_2 `elem` Q}
+          {v_1 ++ v_2 | (a :: v_1) \in P_0, v_2 \in Q}
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
-          concat_lang ({v_1 | (a :: v_1) `elem` P_0}) Q
+          concat_lang ({v_1 | (a :: v_1) \in P_0}) Q
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
           concat_lang (derive_lang_a P_0 a) Q.
@@ -599,10 +594,10 @@ intro s.
 remember (derive_lang_empty {{r}} s) as E; destruct E.
 split.
 - intros.
-  apply e.
+  apply d.
   assumption.
 - intros.
-  apply e0.
+  apply d0.
   assumption.
 Qed.
 

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -12,9 +12,9 @@ Require Import Brzozowski.Regex.
 Require Import Brzozowski.Language.
 
 (*
-The introduction of arbitrary Boolean functions enriches the language of regular expressions. 
-For example, suppose we desire to represent the set of all sequences having three consecutive 1's 
-but not those ending in 01 or consisting of 1's only. 
+The introduction of arbitrary Boolean functions enriches the language of regular expressions.
+For example, suppose we desire to represent the set of all sequences having three consecutive 1's
+but not those ending in 01 or consisting of 1's only.
 The desired expression is easily seen to be:
 
 R = (I.1.1.1.I)\&(I.0.1+1.1^{*})'.
@@ -163,15 +163,13 @@ Lemma test_notelem_starx1_110:
 Proof.
 untie.
 invs H.
-- listerine.
-- invs H0.
-  wreckit.
-  listerine; (try invs L).
-  + apply test_notelem_starx1_10.
-    assumption. 
-Qed.    
+invs H2.
+listerine.
+apply test_notelem_starx1_10.
+assumption.
+Qed.
 
-Lemma test_notelem_x11star_1110: 
+Lemma test_notelem_x11star_1110:
   ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{x11star}}.
 Proof.
 untie.
@@ -182,7 +180,7 @@ listerine; (try invs L).
   assumption.
 Qed.
 
-Lemma test_elem_xI111I_1110: 
+Lemma test_elem_xI111I_1110:
     ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
 Proof.
 constructor.
@@ -216,7 +214,7 @@ split.
           untie.
 Qed.
 
-Theorem test_exampleR_1110_elem: 
+Theorem test_exampleR_1110_elem:
     ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{exampleR}}.
 Proof.
 constructor.
@@ -248,9 +246,9 @@ split.
   + untie.
     apply test_notelem_x11star_1110.
     assumption.
-Qed. 
+Qed.
 
-Theorem test_exampleR_111_notelem: 
+Theorem test_exampleR_111_notelem:
     [A1; A1; A1] `notelem` {{exampleR}}.
 Proof.
 untie.
@@ -275,22 +273,15 @@ exists [A1; A1].
 exists eq_refl.
 wreckit.
 - constructor.
-- apply mk_star_more.
-  constructor.
-  exists [].
-  exists A1.
-  exists [A1].
-  exists eq_refl.
-  wreckit.
-  + constructor.
-  + apply mk_star_more.
+- apply mk_star_more with (p := [A1]) (q := [A1]).
+  + listerine. reflexivity.
+  + listerine.
+  + fold (denote_regex x1).
     constructor.
-    exists [].
-    exists A1.
-    exists [].
-    exists eq_refl.
-    wreckit.
+  + fold (denote_regex x1).
+    apply mk_star_more with (p := [A1]) (q := []).
+    * now listerine.
+    * listerine.
     * constructor.
     * constructor.
-      reflexivity.
-Qed.   
+Qed.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -26,8 +26,8 @@ Definition xI01 := concat I (concat x0 x1).
 Definition x11star := concat x1 (star x1).
 Definition exampleR := and xI111I (complement (or xI01 x11star)).
 
-Lemma test_elem_xI01_101:
-  ([A1] ++ [A0] ++ [A1]) `elem` {{xI01}}.
+Lemma test_in_xI01_101:
+  ([A1] ++ [A0] ++ [A1]) \in {{xI01}}.
 Proof.
 unfold xI01.
 constructor.
@@ -38,7 +38,7 @@ exists H.
 constructor.
 - constructor.
   wreckit.
-  apply notelem_emptyset.
+  apply notin_emptyset.
 - constructor.
   exists [A0].
   exists [A1].
@@ -48,94 +48,93 @@ constructor.
   + constructor.
 Qed.
 
-Lemma test_notelem_xI01_101_false:
-  ([A1] ++ [A0] ++ [A1]) `notelem` {{xI01}}  -> False.
+Lemma test_notin_xI01_101_false:
+  ([A1] ++ [A0] ++ [A1]) \notin {{xI01}}  -> False.
 Proof.
 unfold not.
 intros.
 apply H.
-apply test_elem_xI01_101.
+apply test_in_xI01_101.
 Qed.
 
-Local Ltac elemt :=
+Local Ltac int :=
   match goal with
-  | [ H : _ `elem` _ |- _ ] =>
+  | [ H : _ \in _ |- _ ] =>
     inversion H; clear H
-  | [ |- context [_ `notelem` _ ] ] =>
+  | [ |- context [_ \notin _ ] ] =>
     unfold not; intros
   end.
 
 Lemma test_notleme_xI01_empty:
-    [] `notelem` {{xI01}}.
+    [] \notin {{xI01}}.
 Proof.
-elemt.
-elemt.
+int.
+int.
 wreckit.
-elemt.
+int.
 subst.
 cbn in x3.
-apply app_eq_nil in x3.
+listerine.
+invs R.
 wreckit.
-assert ([A0; A1] <> []).
-discriminate.
-subst.
-elemt.
-elemt.
-subst.
-contradiction.
+listerine.
+invs R.
 Qed.
 
-Lemma test_notelem_xI01_10:
-  ([A1] ++ [A0]) `notelem` {{xI01}}.
+Lemma test_notin_xI01_10:
+  ([A1] ++ [A0]) \notin {{xI01}}.
 Proof.
-elemt.
-elemt.
+int.
+int.
 wreckit.
-elemt.
+int.
 wreckit.
-elemt.
-elemt.
-elemt.
+int.
+int.
+int.
 wreckit.
 subst.
 assert (x ++ [A0] ++ [A1] <> [A1] ++ [A0]).
 listerine.
+apply H.
+listerine.
+- unfold "\notin" .
 contradiction.
 Qed.
 
-Lemma test_notelem_xI01_1110:
-  ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{xI01}}.
+Lemma test_notin_xI01_1110:
+  ([A1] ++ [A1] ++ [A1] ++ [A0]) \notin {{xI01}}.
 Proof.
-elemt.
-elemt.
+int.
+int.
 wreckit.
-elemt.
+int.
 wreckit.
-elemt.
-elemt.
+int.
+int.
 subst.
 cbn in x3.
 listerine.
 Qed.
 
-Lemma test_notelem_x11star_0:
-  [A0] `notelem` {{ x11star }}.
+Lemma test_notin_x11star_0:
+  [A0] \notin {{ x11star }}.
 Proof.
-elemt.
-elemt.
+int.
+int.
 wreckit.
-elemt.
+int.
 - subst.
   listerine.
   subst.
-  elemt.
-- elemt.
+  int.
+- int.
   + wreckit. subst. inversion H2. subst. cbn in x3. listerine.
   + wreckit. subst. inversion H2. subst. cbn in x3. listerine.
 Qed.
 
-Lemma test_notelem_starx1_0:
-  [A0] `notelem` {{star x1}}.
+Lemma test_notin_starx1_0:
+  [A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
@@ -145,8 +144,8 @@ invs H.
   + inversion H2.
 Qed.
 
-Lemma test_notelem_starx1_10:
-  [A1; A0] `notelem` {{star x1}}.
+Lemma test_notin_starx1_10:
+  [A1; A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
@@ -158,30 +157,30 @@ invs H.
   + invs H2.
 Qed.
 
-Lemma test_notelem_starx1_110:
-  [A1; A1; A0] `notelem` {{star x1}}.
+Lemma test_notin_starx1_110:
+  [A1; A1; A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
 invs H2.
 listerine.
-apply test_notelem_starx1_10.
+apply test_notin_starx1_10.
 assumption.
 Qed.
 
-Lemma test_notelem_x11star_1110:
-  ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{x11star}}.
+Lemma test_notin_x11star_1110:
+  ([A1] ++ [A1] ++ [A1] ++ [A0]) \notin {{x11star}}.
 Proof.
 untie.
 invs H.
 wreckit.
 listerine; (try invs L).
-- apply test_notelem_starx1_110.
+- apply test_notin_starx1_110.
   assumption.
 Qed.
 
-Lemma test_elem_xI111I_1110:
-    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
+Lemma test_in_xI111I_1110:
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) \in {{xI111I}}.
 Proof.
 constructor.
 exists [].
@@ -214,8 +213,8 @@ split.
           untie.
 Qed.
 
-Theorem test_exampleR_1110_elem:
-    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{exampleR}}.
+Theorem test_exampleR_1110_in:
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) \in {{exampleR}}.
 Proof.
 constructor.
 split.
@@ -223,7 +222,7 @@ split.
   invs H.
   wreckit.
   apply L.
-  apply test_elem_xI111I_1110.
+  apply test_in_xI111I_1110.
 - untie.
   invs H.
   wreckit.
@@ -241,15 +240,15 @@ split.
   constructor.
   wreckit.
   + untie.
-    apply test_notelem_xI01_1110.
+    apply test_notin_xI01_1110.
     assumption.
   + untie.
-    apply test_notelem_x11star_1110.
+    apply test_notin_x11star_1110.
     assumption.
 Qed.
 
-Theorem test_exampleR_111_notelem:
-    [A1; A1; A1] `notelem` {{exampleR}}.
+Theorem test_exampleR_111_notin:
+    [A1; A1; A1] \notin {{exampleR}}.
 Proof.
 untie.
 invs H.


### PR DESCRIPTION
I started renaming `elem` to `\in` and `notelem` to `\notin`, but I encountered some problems:

when I used the tactic:
`assert (x ++ [A0] ++ [A1] <> [A1] ++ [A0]).`
then I get the following goal:
`[A1] ++ [A0] \notin ((alphabet \in list) \in @eq) (x ++ [A0] ++ [A1])`
Maybe there is something I need to unimport to not have this syntax,
because now I also cannot use contradiction in the `Lemma test_notin_xI01_10`

When I apply the newly assert hypothesis, after I proved it to False,
`apply H.`
I again get:
x ++ [A0] ++ [A1] = [A1] ++ [A0]
So I believe it has something to do with notin, maybe?

This is unfortunately not just syntactical actually influences which tactics we can use.

My first guess is that this syntax is already used in a somewhat standard library, see https://coq.inria.fr/library/Coq.ssr.ssrbool.html
It is quite possible that we end up using ssreflect, but for now, I would like things to keep on working until we get to that part of Coq Art and decide whether it is really appropriate.

