### PR TITLE
clean up

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -12,6 +12,7 @@ src/CoqStock/reduce_orb.v
 src/CoqStock/sort.v
 src/CoqStock/Invs.v
 src/CoqStock/Lem.v
+src/CoqStock/List.v
 src/CoqStock/Listerine.v
 src/CoqStock/Untie.v
 src/CoqStock/WreckIt.v

--- a/src/Brzozowski/Boolean.v
+++ b/src/Brzozowski/Boolean.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.WreckIt.
 Require Import CoqStock.Listerine.

--- a/src/Brzozowski/Boolean.v
+++ b/src/Brzozowski/Boolean.v
@@ -1,7 +1,5 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.WreckIt.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 
 Require Import Brzozowski.Alphabet.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -1,12 +1,9 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
-Require Import CoqStock.List.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Language.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -1,8 +1,6 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Listerine.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -1,11 +1,9 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Invs.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
+Require Import CoqStock.List.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Delta.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.Invs.
 Require Import CoqStock.Listerine.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -1,7 +1,5 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.Invs.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -109,127 +109,6 @@ constructor; constructor; invs H1; wreckit;
     assumption.
 Qed.
 
-Inductive concat_prefix_not_empty_lang (P Q: lang): lang :=
-  | mk_concat_prefix_is_not_empty: forall (s: str),
-    (exists
-      (p: str)
-      (a: alphabet)
-      (q: str)
-      (pqs: (a :: p) ++ q = s),
-      (a :: p) `elem` P /\
-      q `elem` Q
-    ) ->
-    concat_prefix_not_empty_lang P Q s
-  .
-
-Theorem concat_prefix_not_empty_lang_is_concat_lang:
-  forall (P Q: lang) (s: str),
-  concat_prefix_not_empty_lang P Q s ->
-  concat_lang P Q s.
-Proof.
-intros.
-inversion H.
-wreckit.
-subst.
-constructor.
-exists (x0 :: x).
-exists x1.
-exists eq_refl.
-wreckit; assumption.
-Qed.
-
-Theorem concat_lang_is_concat_prefix_not_empty_lang:
-  forall (P Q: lang) (s: str),
-  [] `notelem` P ->
-  concat_lang P Q s ->
-  concat_prefix_not_empty_lang P Q s.
-Proof.
-intros.
-inversion H0.
-wreckit.
-subst.
-destruct x.
-- contradiction.
-- constructor.
-  exists x.
-  exists a.
-  exists x0.
-  exists eq_refl.
-  wreckit; assumption.
-Qed.
-
-(*
-   concat_prefix_not_empty_lang_morph allows rewrite to work inside concat_prefix_not_empty_lang parameters
-*)
-Add Parametric Morphism: concat_prefix_not_empty_lang
-  with signature lang_iff ==> lang_iff ==> lang_iff as concat_prefix_not_empty_lang_morph.
-Proof.
-intros P P'.
-intros Piff.
-intros Q Q'.
-intros Qiff.
-unfold "{<->}" in *.
-unfold "`elem`" in *.
-split.
-- intro H.
-  invs H.
-  destruct H0 as [p [a [q [splt [Pmatch Qmatch]]]]].
-  constructor.
-  exists p.
-  exists a.
-  exists q.
-  exists splt.
-  wreckit.
-  + specialize Piff with (a :: p).
-    apply Piff.
-    assumption.
-  + specialize Qiff with q.
-    apply Qiff.
-    assumption.
-- intro H.
-  invs H.
-  destruct H0 as [p [a [q [splt [Pmatch Qmatch]]]]].
-  constructor.
-  exists p.
-  exists a.
-  exists q.
-  exists splt.
-  wreckit.
-  + specialize Piff with (a :: p).
-    apply Piff.
-    assumption.
-  + specialize Qiff with q.
-    apply Qiff.
-    assumption.
-Qed.
-
-
-(*
-
-Different possible definitions of star_lang:
-
-- allowing empty prefixes in `mk_star_more` or not
-- using an existence statement or not
-
-This gives 4 equivalent definitions.
-
-The definitions that use an existence statement (e.g. the existence statement
-that is part of `concat_lang` and `concat_prefix_not_empty_lang`) require you to
-prove your own induction principle, because Coq is not smart enough to figure it
-out by itself. The definitions that allow empty prefixes make induction more
-difficult if the regular expression matches the empty string.
-
-Therefore, the easiest definition is the one that does not have an existence
-statement and that does not allow empty prefixes, and I suggest that we use that
-one as our main definition.
-
-Below, we define all these definitions and prove their equivalence. As part of
-the proofs, we prove a stronger induction principle for the two definitions that
-use an existence statement.
-
-*)
-
-(* Most convenient definition. *)
 Inductive star_lang (R: lang): lang :=
   | mk_star_zero : star_lang R []
   | mk_star_more : forall (s p q: str),
@@ -408,6 +287,7 @@ Proof.
     induction not_x.
 Abort.
 
+(* This lemma is only here to show off the setoid rewrite example below. *)
 Example lemma_for_setoid_example_concat_lang_emptyset_l_is_emptyset: forall (r: lang),
   concat_lang emptyset_lang r
   {<->}

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -1,6 +1,6 @@
-Require Import List.
-Import ListNotations.
-Require Import Setoid.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
+Require Import Coq.Setoids.Setoid.
 
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -1,9 +1,8 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
 Require Import Coq.Setoids.Setoid.
 
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -2,8 +2,8 @@
    Language definitions of regular expressions are equivalent.
 *)
 
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -2,11 +2,9 @@
    Language definitions of regular expressions are equivalent.
 *)
 
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -1,6 +1,4 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
+Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 
 Require Import Brzozowski.Alphabet.

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.Listerine.
 

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -1,23 +1,76 @@
 Require Import List.
 Import ListNotations.
-Require Import Setoid.
 
-Require Import CoqStock.DubStep.
-Require Import CoqStock.Invs.
 Require Import CoqStock.Listerine.
-Require Import CoqStock.Untie.
-Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
-Require Import Brzozowski.Regex.
-
-Require Import Language.
+Require Import Brzozowski.Language.
 
 (*
-  star_lang_concat is the original definition of star_lang,
-  but contains more recursion, since it allows R to match the empty string.
+This module shows off different possible definitions of star_lang and how they are all equivalent
+to the defintion we use in Language.v, namely `star_lang`.
+The 4 varieties include switching these options on and off:
+
+  - allowing empty prefixes in `mk_star_more`
+  - using an existence statement
+
+Where the definition of the `star_lang` we use in Language.v:
+
+  - does not allow empty prefixes in `mk_star_more`
+  - prefers using forall over existence
+
+The reason for preferring forall over existence in this case is that,
+the definitions that use an existence statement (e.g. the existence statement
+that is part of `concat_lang` and `concat_ex_prefix_not_empty_lang`) require you to
+prove your own induction principle, because Coq is not smart enough to figure it
+out by itself. The definitions that allow empty prefixes make induction more
+difficult if the regular expression matches the empty string.
+
+Therefore, the easiest definition is the one that does not have an existence
+statement and that does not allow empty prefixes, so we will use that as our main definition.
+
+Below, we define all these definitions and prove their equivalence. As part of
+the proofs, we prove a stronger induction principle for the two definitions that
+use an existence statement.
+
+For reference here follows our main definition of `star_lang`
+
+Inductive star_lang (R: lang): lang :=
+  | mk_star_zero : star_lang R []
+  | mk_star_more : forall (s p q: str),
+      p ++ q = s ->
+      p <> [] ->
+      p `elem` R ->
+      q `elem` (star_lang R) ->
+      s `elem` star_lang R.
+
+The other definitions are:
+  - star_lang_ex_empty
+  - star_lang_empty
+  - star_lang_ex
 *)
-(* The definition allowing empty prefixes. *)
+
+(*
+  star_lang_ex_empty is the original definition of star_lang:
+  - Uses existence
+  - Allows empty prefixes in mk_star_more
+  It contains more recursion, since it allows R to match the empty string.
+  The definition allowing empty prefixes and using the existence statement is hidden in `concat_lang`.
+  This is the most difficult definition to use in Coq, but arguably the closest to the mathematical definition:
+    *Star*. $P^{*} = \cup_{0}^{\infty} P^n$ , where $P^2 = P.P$, etc.
+    and $P^0 = \lambda$, the set consisting of the string of zero length.
+*)
+Inductive star_lang_ex_empty (R: lang): lang :=
+  | mk_star_zero_ex_empty : forall (s: str),
+    s = [] -> star_lang_ex_empty R s
+  | mk_star_more_ex_empty : forall (s: str),
+    s `elem` (concat_lang R (star_lang_ex_empty R)) ->
+    star_lang_ex_empty R s.
+
+(* star_lang_empty is a middle ground:
+  - Does not use existence
+  - Allows empty prefixes
+*)
 Inductive star_lang_empty (R: lang): lang :=
   | mk_star_zero_empty : forall (s: str),
       s = [] -> star_lang_empty R s
@@ -27,25 +80,35 @@ Inductive star_lang_empty (R: lang): lang :=
       q `elem` (star_lang_empty R) ->
       s `elem` star_lang_empty R.
 
-(*
-    *Star*. $P^{*} = \cup_{0}^{\infty} P^n$ , where $P^2 = P.P$, etc.
-    and $P^0 = \lambda$, the set consisting of the string of zero length.
+(* concat_ex_prefix_not_empty_lang is a helper for star_lang_ex
+   It uses existence to define concat and
+   the prefix language is not allowed to match the empty string
 *)
-(* Definition using the existence statement (hidden in `concat_prefix_not_empty_lang`). *)
+Inductive concat_ex_prefix_not_empty_lang (P Q: lang): lang :=
+  | mk_concat_prefix_is_not_empty: forall (s: str),
+    (exists
+      (p: str)
+      (a: alphabet)
+      (q: str)
+      (pqs: (a :: p) ++ q = s),
+      (a :: p) `elem` P /\
+      q `elem` Q
+    ) ->
+    concat_ex_prefix_not_empty_lang P Q s
+.
+
+(* star_lang_ex is another middle ground:
+  - Uses existence that is hidden in concat_ex_prefix_not_empty_lang
+  - Does not allow empty prefixes in mk_star_more, which is also hidden in concat_ex_prefix_not_empty_lang
+*)
 Inductive star_lang_ex (R: lang): lang :=
   | mk_star_zero_ex : forall (s: str),
       s = [] -> star_lang_ex R s
   | mk_star_more_ex : forall (s: str),
-      s `elem` (concat_prefix_not_empty_lang R (star_lang_ex R)) ->
+      s `elem` (concat_ex_prefix_not_empty_lang R (star_lang_ex R)) ->
       star_lang_ex R s.
 
-(* The definition allowing empty prefixes and using the existence statement (hidden in `concat_lang`). The most difficult definition to use in Coq, but arguably the closest to the mathematical definition. *)
-Inductive star_lang_ex_empty (R: lang): lang :=
-  | mk_star_zero_ex_empty : forall (s: str),
-      s = [] -> star_lang_ex_empty R s
-  | mk_star_more_ex_empty : forall (s: str),
-      s `elem` (concat_lang R (star_lang_ex_empty R)) ->
-      star_lang_ex_empty R s.
+(* The Propositions below shows how each of the 4 definitions are equivalent to star_lang. *)
 
 Proposition star_lang_empty_equivalent (R: lang): forall (s: str),
    s `elem` star_lang R <-> s `elem` star_lang_empty R.
@@ -58,7 +121,7 @@ Proof.
   - intro Hmatch.
     induction Hmatch as [| s p q Hp_match Hq_match IH].
     + subst. now constructor.
-    + destruct p as [p | a p].
+    + destruct p.
       * (* If the prefix is empty, the induction hypothesis is exactly what we want. *)
         subst.
         cbn.
@@ -69,7 +132,7 @@ Proof.
         listerine.
 Qed.
 
-Proposition star_lang_ex_ind_better:
+Local Proposition star_lang_ex_ind_better:
  forall (R : lang) (P : str -> Prop),
    (* base case *)
    P [] ->
@@ -111,7 +174,7 @@ Proof.
     + subst. now constructor.
     + eapply (mk_star_more_ex R s); try (exact H).
       constructor.
-      destruct p as [p | a p].
+      destruct p.
       * contradiction.
       * exists p.
         exists a.
@@ -127,7 +190,7 @@ Proof.
     + assumption.
 Qed.
 
-Proposition star_lang_ex_empty_ind_better:
+Local Proposition star_lang_ex_empty_ind_better:
  forall (R : lang) (P : str -> Prop),
    (* base case *)
    P [] ->
@@ -167,7 +230,7 @@ Proof.
     + subst. now constructor.
     + eapply (mk_star_more_ex_empty R s); try (exact H).
       constructor.
-      destruct p as [p | a p].
+      destruct p.
       * contradiction.
       * exists (a :: p).
         exists q.
@@ -178,56 +241,9 @@ Proof.
     + now constructor.
     + intros.
       destruct H as [p [q [Hconcat [ Hp_match [Hq_match IH]]]]].
-      destruct p as [p | a p].
+      destruct p.
       * subst. cbn. assumption.
       * constructor 2 with (p := (a :: p)) (q := q); try assumption.
         listerine.
     + assumption.
 Qed.
-
-
-(* A fifth definition of star_lang: this definition includes a notion of
-"depth". It allows empty prefixes, but it uses an integer to keep track of the
-depth of the constructor tree. *)
-Inductive star_lang_max_depth (R: lang): nat -> lang :=
-  | mk_star_zero'' : forall (s: str),
-    s = [] -> star_lang_max_depth R 0 s
-  | mk_star_more'' : forall (s: str) (depth: nat),
-    s `elem` (concat_lang R (star_lang_max_depth R depth)) ->
-    star_lang_max_depth R (S depth) s
-  .
-
-Lemma star_lang_depth_equivalent_helper:
-  forall (R: lang) (depth: nat) (s: str),
-  star_lang_max_depth R depth s -> star_lang R s.
-Proof.
-    induction depth.
-  + intros.
-    invs H.
-    constructor.
-  + intros.
-    invs H.
-    invs H1.
-    wreckit.
-    apply IHdepth in R0.
-    destruct x.
-    * subst.
-      cbn.
-      assumption.
-    * apply mk_star_more with (p := (a ::x)) (q := x0).
-      assumption.
-      listerine.
-      assumption.
-      assumption.
-Qed.
-
-Lemma star_lang_depth_equivalent:
-  forall (R: lang) (s: str),
-    (exists (depth: nat), star_lang_max_depth R depth s) <-> star_lang R s.
-Proof.
-(* TODO: Good First Issue
-
-I don't think we need this lemma anymore, but it could be an interesting first
-issue, or an interesting exercise. (Maybe a difficult first issue, though.)
-*)
-Abort.

--- a/src/CoqStock/List.v
+++ b/src/CoqStock/List.v
@@ -1,0 +1,61 @@
+(* 
+Proofs about Lists that would be nice to have in a standard library.
+*)
+
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
+Require Import Coq.micromega.Lia.
+
+Theorem length_zero_string_is_empty {A: Type} (xs: list A):
+  length xs = 0 -> xs = [].
+Proof.
+  apply length_zero_iff_nil.
+Qed.
+
+Theorem length_zero_or_smaller_string_is_empty {A: Type} (xs: list A):
+  length xs <= 0 -> xs = [].
+Proof.
+  intros.
+  assert (length xs = 0).
+  lia.
+  rewrite length_zero_iff_nil in *.
+  assumption.
+Qed.
+
+Theorem split_list {A: Type} (xs: list A) (n : nat):
+  forall (ys zs: list A),
+    length ys = n ->
+    xs = ys ++ zs ->
+    ys = firstn n xs /\
+    zs = skipn n xs.
+Proof.
+  intros.
+  set (ys' := firstn n xs).
+  set (zs' := skipn n xs).
+  subst.
+
+  set (firstn_app (length ys) ys zs) as Hfirst.
+  replace (length ys - length ys) with 0 in * by lia.
+  replace (firstn 0 zs) with (nil : list A) in * by (symmetry; apply firstn_O).
+  rewrite app_nil_r in Hfirst.
+  replace (firstn (length ys) ys) with ys in Hfirst by (symmetry; apply firstn_all).
+
+  set (skipn_app (length ys) ys zs) as Hlast.
+  replace (length ys - length ys) with 0 in * by lia.
+  replace (skipn (length ys) ys) with (nil: list A) in Hlast by (symmetry; apply skipn_all).
+  rewrite app_nil_l in Hlast.
+  replace (skipn 0 zs) with zs in Hlast by (apply skipn_O).
+
+  split; auto.
+Qed.
+
+Lemma prefix_leq_length {A: Type} (xs ys zs: list A):
+  xs = ys ++ zs -> length ys <= length xs.
+Proof.
+  intro H.
+  assert (length ys + length zs = length xs).
+  replace xs with (ys ++ zs) by assumption.
+  symmetry.
+  exact (app_length ys zs).
+  lia.
+Qed.

--- a/src/CoqStock/List.v
+++ b/src/CoqStock/List.v
@@ -1,9 +1,11 @@
-(* 
-Proofs about Lists that would be nice to have in a standard library.
+(*
+This module replaces the standard library's List module.
+It reexports Coq.Lists.List and Coq.Lists.List.ListNotations.
+It includes extra theorems about lists.
 *)
 
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
+Require Export Coq.Lists.List.
+Export Coq.Lists.List.ListNotations.
 Require Import Coq.micromega.Lia.
 
 Theorem length_zero_string_is_empty {A: Type} (xs: list A):

--- a/src/CoqStock/Listerine.v
+++ b/src/CoqStock/Listerine.v
@@ -44,8 +44,8 @@ end.
 replace `inversion H; clear H; subst` with a theorem `apply NewTheorem in H`.
 *)
 
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 (* list_empty:
    finds empty lists in the hypotheses and the goal and tries to apply an appropriate tactic:

--- a/src/CoqStock/Truthy.v
+++ b/src/CoqStock/Truthy.v
@@ -5,8 +5,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-From Coq Require Import Ring.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
+Require Import Coq.setoid_ring.Ring.
 
 (* bool_semi_ring creates a semi ring 
    , using `or` and `and` boolean expressions 

--- a/src/CoqStock/comparable.v
+++ b/src/CoqStock/comparable.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Class comparable (A : Type) :=
   { compare : A -> A -> comparison (* Eq | Lt | Gt *)

--- a/src/CoqStock/compare_nat.v
+++ b/src/CoqStock/compare_nat.v
@@ -6,7 +6,7 @@ which is a instance of comparable for nat.
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
 

--- a/src/CoqStock/dup.v
+++ b/src/CoqStock/dup.v
@@ -1,8 +1,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.comparable.
 Require Import CoqStock.sort.

--- a/src/CoqStock/list_set.v
+++ b/src/CoqStock/list_set.v
@@ -9,8 +9,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Section list_set_eq.
   Context {A: Type}.

--- a/src/CoqStock/reduce_orb.v
+++ b/src/CoqStock/reduce_orb.v
@@ -1,4 +1,4 @@
-Require Import Bool.
+Require Import Coq.Bool.Bool.
 
 Ltac reduce_orb_step :=
   match goal with

--- a/src/CoqStock/reorder.v
+++ b/src/CoqStock/reorder.v
@@ -12,7 +12,8 @@ Then reordering the tree should result in the same answer.
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
+
 Require Import CoqStock.comparable.
 
 Section Reorder.

--- a/src/CoqStock/sort.v
+++ b/src/CoqStock/sort.v
@@ -1,10 +1,9 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
-
-Require Import Psatz.
-Require Import Lia.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
+Require Import Coq.micromega.Psatz.
 
 Require Import CoqStock.comparable.
 Require Import CoqStock.DubStep.

--- a/src/Reexamined/derive.v
+++ b/src/Reexamined/derive.v
@@ -1,9 +1,9 @@
-Require Import List.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
-Require Import CoqStock.Truthy.
 Require Import CoqStock.reduce_orb.
+Require Import CoqStock.Truthy.
 
 Require Import Reexamined.compare_regex.
 Require Export Reexamined.derive_def.

--- a/src/Reexamined/derive.v
+++ b/src/Reexamined/derive.v
@@ -1,7 +1,7 @@
 Require Import Coq.Bool.Bool.
-Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 Require Import CoqStock.reduce_orb.
 Require Import CoqStock.Truthy.
 

--- a/src/Reexamined/derive_def.v
+++ b/src/Reexamined/derive_def.v
@@ -1,7 +1,8 @@
-Require Import List.
-Require Import Bool.
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.nullable.
 Require Import Reexamined.regex.
 

--- a/src/Reexamined/derive_def.v
+++ b/src/Reexamined/derive_def.v
@@ -1,7 +1,7 @@
 Require Import Coq.Bool.Bool.
-Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.nullable.
 Require Import Reexamined.regex.

--- a/src/Reexamined/main.v
+++ b/src/Reexamined/main.v
@@ -1,9 +1,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import Coq.Lists.List.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.

--- a/src/Reexamined/main.v
+++ b/src/Reexamined/main.v
@@ -1,9 +1,10 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.
 Require Import Reexamined.nullable.

--- a/src/Reexamined/matches_pred.v
+++ b/src/Reexamined/matches_pred.v
@@ -1,7 +1,5 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.derive_def.
 Require Import Reexamined.regex.

--- a/src/Reexamined/matches_pred.v
+++ b/src/Reexamined/matches_pred.v
@@ -1,5 +1,5 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.comparable.
 

--- a/src/Reexamined/matches_pred_proofs.v
+++ b/src/Reexamined/matches_pred_proofs.v
@@ -1,8 +1,9 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.comparable.
 Require Import CoqStock.WreckIt.
+
 Require Import Reexamined.regex.
 Require Import Reexamined.matches_pred.
 

--- a/src/Reexamined/matches_pred_proofs.v
+++ b/src/Reexamined/matches_pred_proofs.v
@@ -1,7 +1,5 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 Require Import CoqStock.WreckIt.
 
 Require Import Reexamined.regex.

--- a/src/Reexamined/nullable.v
+++ b/src/Reexamined/nullable.v
@@ -1,6 +1,5 @@
-Require Import Coq.Lists.List.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.regex.
 

--- a/src/Reexamined/nullable.v
+++ b/src/Reexamined/nullable.v
@@ -1,6 +1,7 @@
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.regex.
 
 (* nullable returns whether the regular expression matchesb the

--- a/src/Reexamined/regex.v
+++ b/src/Reexamined/regex.v
@@ -1,4 +1,5 @@
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 (* A character for a regular expression is generic,
    but it needs to implement an interface.

--- a/src/Reexamined/set_of_sequences.v
+++ b/src/Reexamined/set_of_sequences.v
@@ -1,8 +1,9 @@
-Require Import List.
-Import ListNotations.
+Require Import Coq.Lists.List.
+Import Coq.Lists.List.ListNotations.
 
 Require Import CoqStock.comparable.
 Require Import CoqStock.compare_nat.
+
 Require Import Reexamined.regex.
 Require Import Reexamined.derive_def.
 

--- a/src/Reexamined/set_of_sequences.v
+++ b/src/Reexamined/set_of_sequences.v
@@ -1,8 +1,6 @@
-Require Import Coq.Lists.List.
-Import Coq.Lists.List.ListNotations.
-
 Require Import CoqStock.comparable.
 Require Import CoqStock.compare_nat.
+Require Import CoqStock.List.
 
 Require Import Reexamined.regex.
 Require Import Reexamined.derive_def.

--- a/src/Reexamined/setoid.v
+++ b/src/Reexamined/setoid.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 
-Require Export Relation_Definitions.
-Require Export Setoid.
+Require Export Coq.Relations.Relation_Definitions.
+Require Export Coq.Setoids.Setoid.
 
 Require Import CoqStock.comparable.
 

--- a/src/Reexamined/simple.v
+++ b/src/Reexamined/simple.v
@@ -1,9 +1,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import Coq.Lists.List.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.

--- a/src/Reexamined/simple.v
+++ b/src/Reexamined/simple.v
@@ -1,7 +1,7 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
 

--- a/src/Reexamined/simplified.v
+++ b/src/Reexamined/simplified.v
@@ -2,6 +2,7 @@ Set Implicit Arguments.
 Set Asymmetric Patterns.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.nullable.
 Require Import Reexamined.regex.

--- a/src/Reexamined/size.v
+++ b/src/Reexamined/size.v
@@ -1,9 +1,10 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.regex.
 
 Fixpoint size {A: Type} {cmp: comparable A} (r: regex A) := 

--- a/src/Reexamined/size.v
+++ b/src/Reexamined/size.v
@@ -1,9 +1,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import Coq.Lists.List.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.regex.
 

--- a/src/Reexamined/smart.v
+++ b/src/Reexamined/smart.v
@@ -1,9 +1,8 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import Coq.Lists.List.
-
 Require Import CoqStock.comparable.
+Require Import CoqStock.List.
 
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.

--- a/src/Reexamined/smart.v
+++ b/src/Reexamined/smart.v
@@ -1,9 +1,10 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import List.
+Require Import Coq.Lists.List.
 
 Require Import CoqStock.comparable.
+
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.
 Require Import Reexamined.nullable.

--- a/src/Reexamined/smart_or.v
+++ b/src/Reexamined/smart_or.v
@@ -2,14 +2,14 @@ Set Implicit Arguments.
 Set Asymmetric Patterns.
 
 Require Import Coq.Bool.Bool.
-Require Import Coq.Lists.List.
 Require Import Coq.micromega.Lia.
 Require Import Coq.Program.Program.
 
-Require Import CoqStock.Truthy.
 Require Import CoqStock.comparable.
 Require Import CoqStock.dup.
+Require Import CoqStock.List.
 Require Import CoqStock.sort.
+Require Import CoqStock.Truthy.
 
 Require Import Reexamined.compare_regex.
 Require Import Reexamined.derive.

--- a/src/Reexamined/smart_or.v
+++ b/src/Reexamined/smart_or.v
@@ -1,10 +1,9 @@
 Set Implicit Arguments.
 Set Asymmetric Patterns.
 
-Require Import Bool.
-Require Import Lia.
-Require Import List.
-
+Require Import Coq.Bool.Bool.
+Require Import Coq.Lists.List.
+Require Import Coq.micromega.Lia.
 Require Import Coq.Program.Program.
 
 Require Import CoqStock.Truthy.


### PR DESCRIPTION
tl;dr This is all just moving things around, cleanup, some extra comments and removing a few things.

Each heading describes a commit

## Cleanup Starlang

  - Moved somethings from Language.v to StarLang.v so that Language can be a little cleaner
  - Then added some more comments to StarLang.v
  - Removed some definitions and proofs that weren't really used in StarLang.v
  - Cleaned up the `destruct p as [p | a p].` statements to remove the warnings produced the coqc

## Create List Module

  - Moved theorems about lists in Decidable.v into CoqStock/List.v
  - Import everything with full qualified names, since List now has a name conflict

## Replace the Standard Library List Module

  - Use Require Export to export the List module and ListNotations from CoqStock.List, this way you only have to import CoqStock.List to get all the goodies.
  - Replace all imports outside of CoqStock itself of Coq.Lists.List and Coq.Lists.List.ListNotations with CoqStock.List