### PR TITLE
new definition of concat

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -37,6 +37,7 @@ src/Brzozowski/Alphabet.v
 src/Brzozowski/Boolean.v
 src/Brzozowski/Decidable.v
 src/Brzozowski/Delta.v
+src/Brzozowski/ConcatLang.v
 src/Brzozowski/Derive.v
 src/Brzozowski/ExampleR.v
 src/Brzozowski/Language.v

--- a/src/Brzozowski/ConcatLang.v
+++ b/src/Brzozowski/ConcatLang.v
@@ -1,3 +1,9 @@
+(*
+This module shows off different possible definitions of concat_lang and how they are all equivalent
+to the defintion we use in Language.v, namely `concat_lang`.
+This also includes the tactic `destruct_concat_lang`, which is a useful replacement for the constructor tactic when concat_lang is in the goal.
+*)
+
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
 Require Import CoqStock.List.
@@ -9,6 +15,14 @@ Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Language.
 Require Import Brzozowski.Regex.
 
+(*
+concat_lang_ex uses exists to define concat,
+instead of forall as is done by `concat_lang`.
+This is arguably closer to the mathematical definition of concat.
+
+  $(P.Q) = \{ s | s = p.q; p \in P, q \in Q \}$.
+
+*)
 Inductive concat_lang_ex (P Q: lang): lang :=
   | mk_concat_ex: forall (s: str),
     (exists
@@ -21,6 +35,10 @@ Inductive concat_lang_ex (P Q: lang): lang :=
     concat_lang_ex P Q s
   .
 
+(*
+concat_ex_equivalent shows how `concat_lang_ex` is equivalent to
+the main definition of `concat_lang`.
+*)
 Theorem concat_ex_equivalent (P Q: lang):
   concat_lang_ex P Q {<->} concat_lang P Q.
 Proof.
@@ -38,18 +56,26 @@ split.
   split; assumption.
 Qed.
 
-Ltac destruct_concat :=
+(*
+When concat is in the goal, it can be harder to apply the tactic,
+since now some variables need to be provided to mk_concat.
+The destruct_concat_lang tactic solves this by replacing the
+concat_lang definition with the concat_lang_ex definition,
+which can be easily deconstructed.
+*)
+Ltac destruct_concat_lang :=
   apply concat_ex_equivalent;
   fold denote_regex;
   apply mk_concat_ex.
 
-Example deconstruct_concat:
+(* example_destruct_concat_lang shows how the destruct_concat_lang can be used. *)
+Example example_destruct_concat_lang:
   forall (p q: regex),
   [] `elem` {{p}} /\ [] `elem` {{q}} ->
   [] `elem` {{concat p q}}.
 Proof.
 intros.
-destruct_concat.
+destruct_concat_lang.
 exists [].
 exists [].
 listerine.

--- a/src/Brzozowski/ConcatLang.v
+++ b/src/Brzozowski/ConcatLang.v
@@ -1,0 +1,58 @@
+Require Import CoqStock.DubStep.
+Require Import CoqStock.Invs.
+Require Import CoqStock.List.
+Require Import CoqStock.Listerine.
+Require Import CoqStock.Untie.
+Require Import CoqStock.WreckIt.
+
+Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.Language.
+Require Import Brzozowski.Regex.
+
+Inductive concat_lang_ex (P Q: lang): lang :=
+  | mk_concat_ex: forall (s: str),
+    (exists
+      (p: str)
+      (q: str)
+      (pqs: p ++ q = s),
+      p `elem` P /\
+      q `elem` Q
+    ) ->
+    concat_lang_ex P Q s
+  .
+
+Theorem concat_ex_equivalent (P Q: lang):
+  concat_lang_ex P Q {<->} concat_lang P Q.
+Proof.
+split.
+- intros.
+  destruct H.
+  destruct H as [p [q [H [Hp Hq]]]].
+  apply (mk_concat P Q p q s); assumption.
+- intros.
+  destruct H.
+  constructor.
+  exists p.
+  exists q.
+  exists H.
+  split; assumption.
+Qed.
+
+Ltac destruct_concat :=
+  apply concat_ex_equivalent;
+  fold denote_regex;
+  apply mk_concat_ex.
+
+Example deconstruct_concat:
+  forall (p q: regex),
+  [] `elem` {{p}} /\ [] `elem` {{q}} ->
+  [] `elem` {{concat p q}}.
+Proof.
+intros.
+destruct_concat.
+exists [].
+exists [].
+listerine.
+exists eq_refl.
+assumption.
+Qed.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -1,3 +1,5 @@
+Require Import Coq.micromega.Lia.
+
 Require Import CoqStock.DubStep.
 Require Import CoqStock.Invs.
 Require Import CoqStock.List.
@@ -6,10 +8,9 @@ Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
 Require Import Brzozowski.Regex.
-
-Require Import Lia.
 
 Definition regex_is_decidable (r: regex) :=
     (forall s: str, s `elem` {{r}} \/ s `notelem` {{r}}).
@@ -161,19 +162,21 @@ Proof.
   - right.
     unfold not.
     intro HmatchContr.
-    destruct HmatchContr as [s [s1 [s2 [Hconcat [Hmatchp Hmatchq]]]]].
-    symmetry in Hconcat.
+    destruct HmatchContr.
+    symmetry in H.
 
-    set (Hlen := prefix_leq_length s s1 s2 Hconcat).
+    set (Hlen := prefix_leq_length s p0 q0 H).
 
-    specialize HAllDontMatch with s1 s2.
-    destruct (HAllDontMatch Hconcat Hlen); auto.
+    specialize HAllDontMatch with p0 q0.
+    destruct (HAllDontMatch H Hlen); auto.
 
   - left.
     destruct HExistsMatch as [s1 [s2 [Hconcat [Hlen [Hmatchp Hmatchq]]]]].
-    constructor.
     symmetry in Hconcat.
-    exists s1. exists s2. exists Hconcat.
+    destruct_concat.
+    exists s1.
+    exists s2.
+    exists Hconcat.
     split; assumption.
 Qed.
 
@@ -256,11 +259,11 @@ Proof.
 intros.
 wreckit.
 - left.
-  constructor.
+  destruct_concat.
   exists [].
   exists [].
   exists eq_refl.
-  wreckit; assumption.
+  split; assumption.
 - right.
   untie.
   invs H.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -173,7 +173,7 @@ Proof.
   - left.
     destruct HExistsMatch as [s1 [s2 [Hconcat [Hlen [Hmatchp Hmatchq]]]]].
     symmetry in Hconcat.
-    destruct_concat.
+    destruct_concat_lang.
     exists s1.
     exists s2.
     exists Hconcat.
@@ -259,7 +259,7 @@ Proof.
 intros.
 wreckit.
 - left.
-  destruct_concat.
+  destruct_concat_lang.
   exists [].
   exists [].
   exists eq_refl.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -116,7 +116,7 @@ Theorem delta_concat_is_and_lambda: forall (p q: regex),
 Proof.
 intros.
 constructor.
-destruct_concat.
+destruct_concat_lang.
 exists [].
 exists [].
 assert ([] ++ [] = (@nil alphabet)). cbn. reflexivity.
@@ -139,7 +139,7 @@ Theorem delta_concat_is_and:
 Proof.
 intros.
 invs delta_p; invs delta_q; cbn; constructor; try untie.
-- destruct_concat.
+- destruct_concat_lang.
   exists []. exists []. exists eq_refl.
   split; assumption.
 - invs H1. wreckit. listerine. subst.
@@ -437,7 +437,7 @@ induction r.
   invs IHr1;
   invs IHr2.
   + apply delta_lambda.
-    destruct_concat.
+    destruct_concat_lang.
     exists [].
     exists [].
     exists eq_refl.
@@ -549,7 +549,7 @@ inversion_clear H.
       -- reflexivity.
       -- exfalso.
          apply H0.
-         destruct_concat.
+         destruct_concat_lang.
          exists [].
          exists [].
          exists eq_refl.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -6,6 +6,7 @@ Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Language.
 
@@ -115,7 +116,7 @@ Theorem delta_concat_is_and_lambda: forall (p q: regex),
 Proof.
 intros.
 constructor.
-constructor.
+destruct_concat.
 exists [].
 exists [].
 assert ([] ++ [] = (@nil alphabet)). cbn. reflexivity.
@@ -138,7 +139,7 @@ Theorem delta_concat_is_and:
 Proof.
 intros.
 invs delta_p; invs delta_q; cbn; constructor; try untie.
-- constructor.
+- destruct_concat.
   exists []. exists []. exists eq_refl.
   split; assumption.
 - invs H1. wreckit. listerine. subst.
@@ -436,7 +437,7 @@ induction r.
   invs IHr1;
   invs IHr2.
   + apply delta_lambda.
-    constructor.
+    destruct_concat.
     exists [].
     exists [].
     exists eq_refl.
@@ -503,9 +504,9 @@ inversion_clear H.
   + inversion H0.
   + cbn. reflexivity.
   + inversion H0.
-  + invs H0. wreckit. listerine. subst.
-    remember (IHr1 L).
-    remember (IHr2 R).
+  + invs H0. listerine. subst.
+    remember (IHr1 H1).
+    remember (IHr2 H2).
     cbn.
     rewrite e.
     rewrite e0.
@@ -548,7 +549,7 @@ inversion_clear H.
       -- reflexivity.
       -- exfalso.
          apply H0.
-         constructor.
+         destruct_concat.
          exists [].
          exists [].
          exists eq_refl.

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -6,6 +6,7 @@ Require Import CoqStock.WreckIt.
 Require Import CoqStock.List.
 
 Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Delta.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Language.
@@ -358,25 +359,26 @@ constructor.
 wreckit.
 untie.
 invs H.
+invs H2.
 wreckit.
 listerine.
-- apply delta_lambda in L.
-  apply delta_implies_delta_def in L.
-  apply R2 in R.
-  apply R0.
-  constructor.
+- apply delta_lambda in H0.
+  apply delta_implies_delta_def in H0.
+  apply R2 in H1.
+  apply R.
+  destruct_concat.
   exists [].
   exists s.
   exists eq_refl.
   split.
-  + rewrite L.
+  + rewrite H0.
     constructor.
   + assumption.
-- apply R1 in L.
-  apply L0.
-  constructor.
-  exists L1.
-  exists x0.
+- apply R1 in H0.
+  apply L.
+  destruct_concat.
+  exists L0.
+  exists q.
   exists eq_refl.
   split.
   * assumption.
@@ -403,12 +405,10 @@ constructor.
 split.
 - untie.
   invs H.
-  wreckit.
-  invs L0.
+  invs H1.
 - untie.
   invs H.
-  wreckit.
-  invs L0.
+  invs H1.
 Qed.
 
 (* A helper Lemma for commutes_a_concat *)
@@ -431,12 +431,10 @@ constructor.
 split.
 - untie.
   invs H.
-  wreckit.
-  invs R0.
+  invs H2.
 - untie.
   invs H.
-  wreckit.
-  invs R0.
+  invs H2.
 Qed.
 
 (*

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -366,7 +366,7 @@ listerine.
   apply delta_implies_delta_def in H0.
   apply R2 in H1.
   apply R.
-  destruct_concat.
+  destruct_concat_lang.
   exists [].
   exists s.
   exists eq_refl.
@@ -376,7 +376,7 @@ listerine.
   + assumption.
 - apply R1 in H0.
   apply L.
-  destruct_concat.
+  destruct_concat_lang.
   exists L0.
   exists q.
   exists eq_refl.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -29,7 +29,7 @@ Lemma test_elem_xI01_101:
   ([A1] ++ [A0] ++ [A1]) `elem` {{xI01}}.
 Proof.
 unfold xI01.
-destruct_concat.
+destruct_concat_lang.
 exists [A1].
 exists ([A0] ++ [A1]).
 assert ([A1] ++ [A0] ++ [A1] = [A1; A0; A1]). reflexivity.
@@ -38,7 +38,7 @@ constructor.
 - constructor.
   wreckit.
   apply notelem_emptyset.
-- destruct_concat.
+- destruct_concat_lang.
   exists [A0].
   exists [A1].
   exists eq_refl.
@@ -166,7 +166,7 @@ Qed.
 Lemma test_elem_xI111I_1110:
     ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
 Proof.
-destruct_concat.
+destruct_concat_lang.
 exists [].
 exists ([A1] ++ [A1] ++ [A1] ++ [A0]).
 exists eq_refl.
@@ -174,19 +174,19 @@ split.
 - constructor.
   wreckit.
   untie.
-- destruct_concat.
+- destruct_concat_lang.
   exists [A1].
   exists ([A1] ++ [A1] ++ [A0]).
   exists eq_refl.
   split.
   + constructor.
-  + destruct_concat.
+  + destruct_concat_lang.
     exists [A1].
     exists ([A1] ++ [A0]).
     exists eq_refl.
     split.
     * constructor.
-    * destruct_concat.
+    * destruct_concat_lang.
       exists [A1].
       exists [A0].
       exists eq_refl.
@@ -250,7 +250,7 @@ untie.
 invs H.
 wreckit.
 apply R1.
-destruct_concat.
+destruct_concat_lang.
 exists [A1].
 exists [A1; A1].
 exists eq_refl.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -7,6 +7,7 @@ Require Import CoqStock.WreckIt.
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Boolean.
 Require Import Brzozowski.Regex.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
 
 (*
@@ -28,7 +29,7 @@ Lemma test_elem_xI01_101:
   ([A1] ++ [A0] ++ [A1]) `elem` {{xI01}}.
 Proof.
 unfold xI01.
-constructor.
+destruct_concat.
 exists [A1].
 exists ([A0] ++ [A1]).
 assert ([A1] ++ [A0] ++ [A1] = [A1; A0; A1]). reflexivity.
@@ -37,7 +38,7 @@ constructor.
 - constructor.
   wreckit.
   apply notelem_emptyset.
-- constructor.
+- destruct_concat.
   exists [A0].
   exists [A1].
   exists eq_refl.
@@ -68,19 +69,10 @@ Lemma test_notleme_xI01_empty:
 Proof.
 elemt.
 elemt.
-wreckit.
 elemt.
 subst.
-cbn in x3.
-apply app_eq_nil in x3.
-wreckit.
-assert ([A0; A1] <> []).
-discriminate.
-subst.
+listerine.
 elemt.
-elemt.
-subst.
-contradiction.
 Qed.
 
 Lemma test_notelem_xI01_10:
@@ -88,15 +80,12 @@ Lemma test_notelem_xI01_10:
 Proof.
 elemt.
 elemt.
-wreckit.
-elemt.
-wreckit.
 elemt.
 elemt.
 elemt.
-wreckit.
+elemt.
 subst.
-assert (x ++ [A0] ++ [A1] <> [A1] ++ [A0]).
+assert (p ++ [A0] ++ [A1] <> [A1] ++ [A0]).
 listerine.
 contradiction.
 Qed.
@@ -106,13 +95,10 @@ Lemma test_notelem_xI01_1110:
 Proof.
 elemt.
 elemt.
-wreckit.
 elemt.
-wreckit.
 elemt.
 elemt.
 subst.
-cbn in x3.
 listerine.
 Qed.
 
@@ -121,15 +107,14 @@ Lemma test_notelem_x11star_0:
 Proof.
 elemt.
 elemt.
-wreckit.
 elemt.
 - subst.
   listerine.
   subst.
   elemt.
 - elemt.
-  + wreckit. subst. inversion H2. subst. cbn in x3. listerine.
-  + wreckit. subst. inversion H2. subst. cbn in x3. listerine.
+  + subst. elemt. subst. listerine.
+  + subst. invs H1. invs H5. invs H9. listerine.
 Qed.
 
 Lemma test_notelem_starx1_0:
@@ -173,7 +158,7 @@ Proof.
 untie.
 invs H.
 wreckit.
-listerine; (try invs L).
+listerine; (try invs H1).
 - apply test_notelem_starx1_110.
   assumption.
 Qed.
@@ -181,7 +166,7 @@ Qed.
 Lemma test_elem_xI111I_1110:
     ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
 Proof.
-constructor.
+destruct_concat.
 exists [].
 exists ([A1] ++ [A1] ++ [A1] ++ [A0]).
 exists eq_refl.
@@ -189,19 +174,19 @@ split.
 - constructor.
   wreckit.
   untie.
-- constructor.
+- destruct_concat.
   exists [A1].
   exists ([A1] ++ [A1] ++ [A0]).
   exists eq_refl.
   split.
   + constructor.
-  + constructor.
+  + destruct_concat.
     exists [A1].
     exists ([A1] ++ [A0]).
     exists eq_refl.
     split.
     * constructor.
-    * constructor.
+    * destruct_concat.
       exists [A1].
       exists [A0].
       exists eq_refl.
@@ -265,7 +250,7 @@ untie.
 invs H.
 wreckit.
 apply R1.
-constructor.
+destruct_concat.
 exists [A1].
 exists [A1; A1].
 exists eq_refl.

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -75,14 +75,10 @@ Existing Instance lang_setoid.
 
 (* Concatenation*. $(P.Q) = \{ s | s = p.q; p \in P, q \in Q \}$. *)
 Inductive concat_lang (P Q: lang): lang :=
-  | mk_concat: forall (s: str),
-    (exists
-      (p: str)
-      (q: str)
-      (pqs: p ++ q = s),
-      p `elem` P /\
-      q `elem` Q
-    ) ->
+  | mk_concat: forall (p q s: str),
+    p ++ q = s ->
+    p `elem` P ->
+    q `elem` Q ->
     concat_lang P Q s
   .
 
@@ -93,19 +89,19 @@ Add Parametric Morphism: concat_lang
   with signature lang_iff ==> lang_iff ==> lang_iff as concat_lang_morph.
 Proof.
 intros.
-constructor; constructor; invs H1; wreckit;
-  exists x1;
-  exists x2;
-  exists x3;
-  wreckit.
-  + apply H.
-    assumption.
-  + apply H0.
-    assumption.
-  + apply H.
-    assumption.
-  + apply H0.
-    assumption.
+split.
+- intros.
+  destruct H1.
+  apply (mk_concat _ _  p q s).
+  + assumption.
+  + apply H. assumption.
+  + apply H0. assumption.
+- intros.
+  destruct H1.
+  apply (mk_concat _ _  p q s).
+  + assumption.
+  + apply H. assumption.
+  + apply H0. assumption.
 Qed.
 
 Inductive star_lang (R: lang): lang :=
@@ -295,8 +291,7 @@ Proof.
 split.
 - intros.
   invs H.
-  wreckit.
-  invs L.
+  invs H1.
 - intros.
   invs H.
 Qed.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -10,6 +10,7 @@ Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
 Require Import Brzozowski.Regex.
 
@@ -54,8 +55,7 @@ Proof.
 split.
 - intros.
   invs H.
-  wreckit.
-  invs L.
+  invs H1.
 - intros.
   invs H.
 Qed.
@@ -68,8 +68,7 @@ Proof.
 split.
 - intros.
   invs H.
-  wreckit.
-  invs R.
+  invs H2.
 - intros.
   invs H.
 Qed.
@@ -80,8 +79,7 @@ Proof.
 intros.
 untie.
 invs H.
-wreckit.
-invs R.
+invs H2.
 Qed.
 
 Theorem concat_lang_lambda_l_is_l: forall (r: lang),
@@ -92,13 +90,11 @@ Proof.
 split.
 - intros.
   invs H.
-  wreckit.
-  subst.
-  inversion_clear L.
+  inversion_clear H1.
   cbn.
   assumption.
 - intros.
-  constructor.
+  destruct_concat.
   exists [].
   exists s.
   exists eq_refl.
@@ -117,11 +113,11 @@ split.
   invs H.
   wreckit.
   subst.
-  inversion_clear R.
+  inversion_clear H2.
   listerine.
   assumption.
 - intros.
-  constructor.
+  destruct_concat.
   exists s.
   exists [].
   assert (s ++ [] = s). listerine. reflexivity.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -94,7 +94,7 @@ split.
   cbn.
   assumption.
 - intros.
-  destruct_concat.
+  destruct_concat_lang.
   exists [].
   exists s.
   exists eq_refl.
@@ -117,7 +117,7 @@ split.
   listerine.
   assumption.
 - intros.
-  destruct_concat.
+  destruct_concat_lang.
   exists s.
   exists [].
   assert (s ++ [] = s). listerine. reflexivity.

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -2,6 +2,7 @@ Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 
 Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
 
 (*
@@ -53,7 +54,7 @@ The other definitions are:
   - Uses existence
   - Allows empty prefixes in mk_star_more
   It contains more recursion, since it allows R to match the empty string.
-  The definition allowing empty prefixes and using the existence statement is hidden in `concat_lang`.
+  The definition allowing empty prefixes and using the existence statement is hidden in `concat_lang_ex`.
   This is the most difficult definition to use in Coq, but arguably the closest to the mathematical definition:
     *Star*. $P^{*} = \cup_{0}^{\infty} P^n$ , where $P^2 = P.P$, etc.
     and $P^0 = \lambda$, the set consisting of the string of zero length.
@@ -62,7 +63,7 @@ Inductive star_lang_ex_empty (R: lang): lang :=
   | mk_star_zero_ex_empty : forall (s: str),
     s = [] -> star_lang_ex_empty R s
   | mk_star_more_ex_empty : forall (s: str),
-    s `elem` (concat_lang R (star_lang_ex_empty R)) ->
+    s `elem` (concat_lang_ex R (star_lang_ex_empty R)) ->
     star_lang_ex_empty R s.
 
 (* star_lang_empty is a middle ground:
@@ -108,8 +109,8 @@ Inductive star_lang_ex (R: lang): lang :=
 
 (* The Propositions below shows how each of the 4 definitions are equivalent to star_lang. *)
 
-Proposition star_lang_empty_equivalent (R: lang): forall (s: str),
-   s `elem` star_lang R <-> s `elem` star_lang_empty R.
+Proposition star_lang_empty_equivalent (R: lang):
+  star_lang R {<->} star_lang_empty R.
 Proof.
   split.
   - intro Hmatch.
@@ -163,8 +164,8 @@ destruct Hs_match.
   listerine.
 Qed.
 
-Proposition star_lang_ex_equivalent (R: lang): forall (s: str),
-    s `elem` star_lang R <-> s `elem` star_lang_ex R.
+Proposition star_lang_ex_equivalent (R: lang):
+    star_lang R {<->} star_lang_ex R.
 Proof.
   split.
   - intro Hmatch.
@@ -219,8 +220,8 @@ destruct Hs_match.
   repeat split; try assumption.
 Qed.
 
-Proposition star_lang_ex_empty_equivalent (R: lang): forall (s: str),
-    s `elem` star_lang R <-> s `elem` star_lang_ex_empty R.
+Proposition star_lang_ex_empty_equivalent (R: lang):
+    star_lang R {<->} star_lang_ex_empty R.
 Proof.
   split.
   - intro Hmatch.


### PR DESCRIPTION
As discussed in the pair programming session, here is a new definition for concat that is consistent with the new definition for star_lang.
It includes:
  - a proof to show it is equivalent to the old definition and 
  - a tactic to translate and destruct using the old definition, which is very useful when concat is in the goal