### PR TITLE
Cleaning up decidable

### DIFF
--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -94,6 +94,219 @@ wreckit.
   * assumption.
 Qed.
 
+(*
+  To prove concat is decidable, we have to first show that: 
+  - if a concat expression `concat P Q` matches
+      then there exists some splitting where
+      the prefix matches `P` and the suffix matches `Q`
+  - if a concat expression `concat P Q` does not match
+      then forall splittings
+      the prefix does not match `P`
+      or the suffix does not match `Q`
+  Next we can combine these two lemmas into one decidability lemma.
+  Then we can prove concat is decidable for some maximum length using the above lemma.
+  And finally we can prove concat is decidable using this final lemma.
+*)
+
+Definition elem_of_concat_split (p q: regex) (s: str) (index: nat) :=
+  let prefix := firstn index s in
+  let suffix := skipn index s in
+  (prefix `elem` {{p}} /\ suffix `elem` {{q}}).
+
+Lemma concat_lang_a_split_matches:
+  forall (P Q: regex) (s: str),
+    s `elem` {{ concat P Q }}
+  <->
+  (exists (index: nat) (index_range : index <= length s),
+    elem_of_concat_split P Q s index
+  ).
+Proof.
+intros.
+split.
+- intros s_elem_concat.
+  destruct s_elem_concat.
+  exists (length p).
+  assert (length p <= length s).
+  + rewrite <- H.
+    autorewrite with list.
+    lia.
+  + exists H2.
+    constructor.
+    * rewrite <- H.
+      rewrite firstn_length_prefix_is_prefix.
+      assumption.
+    * rewrite <- H.
+      rewrite skipn_length_prefix_is_suffix.
+      assumption.
+- intros exists_elem.
+  wreckit.
+  unfold elem_of_concat_split in H.
+  wreckit.
+  destruct_concat_lang.
+  exists (firstn x s).
+  exists (skipn x s).
+  assert (firstn x s ++ skipn x s = s) by auto with list.
+  exists H.
+  auto.
+Qed.
+
+Lemma concat_lang_no_split_matches:
+  forall (P Q: regex) (s: str),
+  s `notelem` {{ concat P Q }}
+  <->
+  (forall (index: nat) (index_range : index <= length s),
+    not (elem_of_concat_split P Q s index)
+  ).
+Proof.
+intros.
+split.
+- intros s_not_elem_concat index bounded_index.
+  unfold not.
+  intros elem_of_split.
+  apply s_not_elem_concat.
+  apply concat_lang_a_split_matches.
+  exists index.
+  exists bounded_index.
+  assumption.
+- intros not_elem_of_split.
+  unfold not.
+  intros s_elem_concat.
+  destruct s_elem_concat.
+  specialize not_elem_of_split with (index := length p).
+  rewrite <- H in *.
+  assert (length p <= length (p ++ q)) as bounded by (autorewrite with list; lia).
+  apply not_elem_of_split in bounded as not_elem_of_split'.
+  apply not_elem_of_split'.
+  unfold elem_of_concat_split.
+  rewrite firstn_length_prefix_is_prefix.
+  rewrite skipn_length_prefix_is_suffix.
+  auto.
+Qed.
+
+Theorem concat_lang_a_split_matches_or_no_split_matches:
+  forall (P Q: regex) (s: str),
+      s `elem` {{concat P Q}}
+    \/
+      s `notelem` {{concat P Q}}
+  <->
+      (exists (index: nat) (index_range : index <= length s),
+        elem_of_concat_split P Q s index
+      )
+    \/
+      (forall (index: nat) (index_range : index <= length s),
+        not (elem_of_concat_split P Q s index) 
+      ).
+Proof.
+intros.
+destruct (concat_lang_a_split_matches P Q s).
+destruct (concat_lang_no_split_matches P Q s).
+split; intros decide; destruct decide; eauto.
+Qed.
+
+(* 
+  lift_index_and_max_len_from_disjunction
+  is used to lift the index and its max length bounds
+  out of a disjunction, by applying it on the goal.
+*)
+Theorem lift_index_and_max_len_from_disjunction
+  (P: nat -> Prop) (len: nat):
+  (forall (index : nat) (bounded_index: index <= len),
+      P index
+    \/ 
+      ~ (P index)
+  )
+  ->
+  (
+    (forall (index: nat) (bounded_index: index <= len),
+      ~ (P index)
+    )
+    \/
+    (exists (index: nat) (bounded_index: index <= len),
+      P index
+    )
+  ).
+Proof.
+intro lifted.
+induction len.
+- specialize lifted with (index := 0).
+  assert (0 <= 0) as ofcourse by lia.
+  destruct (lifted ofcourse) as [P0 | notP0].
+  + right.
+    exists 0.
+    split; assumption.
+  + left.
+    intros. 
+    assert (index = 0) as index0 by lia.
+    rewrite index0.
+    assumption.
+- assert (forall (index: nat) (bounded_index: index <= len), P index \/ ~ P index) as smaller_lifted.
+  + intros.
+    apply lifted.
+    lia.
+  + apply IHlen in smaller_lifted.
+    destruct smaller_lifted as [notPindex | Pindex].
+    * assert (S len <= S len) as slen_leq by lia.
+      destruct (lifted (S len) slen_leq) as [PSlen | notPSlen].
+      --- right.
+          exists (S len).
+          split; assumption.
+      --- left.
+          intros.
+          assert (forall (len: nat) (index: nat),
+            index <= S len -> index <= len \/ index = S len
+          ) as breakdown_leq by lia.
+          destruct (breakdown_leq len index bounded_index) as [leqlen | eqSlen].
+          +++ apply notPindex.
+              assumption.
+          +++ rewrite eqSlen.
+              assumption.
+    * right.
+      destruct Pindex as [index [bounded_index Pindex]].
+      exists index.
+      split.
+      --- lia.
+      --- assumption.
+Qed.
+
+Lemma denotation_concat_is_decidable_bounded_len
+  (P Q: regex) (len: nat) (decidableP: regex_is_decidable P) (decidableQ: regex_is_decidable Q):
+  (forall
+    (s: str)
+    (bounded_len: length s <= len),
+    (s `elem` {{concat P Q}} \/ s `notelem` {{concat P Q}})
+  ).
+Proof.
+intros.
+apply concat_lang_a_split_matches_or_no_split_matches.
+rewrite or_comm.
+apply lift_index_and_max_len_from_disjunction.
+unfold elem_of_concat_split.
+unfold regex_is_decidable in *.
+intros.
+specialize decidableP with (s := firstn index s).
+specialize decidableQ with (s := skipn index s).
+destruct decidableP, decidableQ.
+- left. split; assumption.
+- right. untie. destruct H1. contradiction.
+- right. untie. destruct H1. contradiction.
+- right. untie. destruct H1. contradiction.
+Qed.
+
+Lemma denotation_concat_is_decidable (P Q: regex):
+  regex_is_decidable P ->
+  regex_is_decidable Q ->
+  regex_is_decidable (concat P Q).
+Proof.
+unfold regex_is_decidable.
+intros Hp Hq s.
+apply (denotation_concat_is_decidable_bounded_len P Q (length s) Hp Hq).
+lia.
+Qed.
+
+(*
+An alternative proof for concat is decidable that uses a similar technique.
+*)
+
 Definition no_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
   forall (s1 s2: str),
   s = s1 ++ s2 ->
@@ -213,7 +426,7 @@ Proof.
 
 Qed.
 
-Lemma denotation_concat_is_decidable (p q: regex):
+Lemma denotation_concat_is_decidable' (p q: regex):
   regex_is_decidable p ->
   regex_is_decidable q ->
   regex_is_decidable (concat p q).
@@ -245,7 +458,22 @@ Proof.
     split; assumption.
 Qed.
 
-Definition elem_of_split (r: regex) (s: str) (index: nat) :=
+(*
+  To prove star is decidable, we have to first show that: 
+  - if a star expression `star r` matches a non empty string
+      then there exists some splitting where
+      the prefix matches the contained regular expression `r`
+      and the suffix matches `star r`.
+  - if a star expression `star r` does not match a non empty string
+      then forall splittings
+      the prefix does not match the contained regular expressions `r`
+      or the suffix does not match `star r`
+  Next we can combine these two lemmas into one decidability lemma.
+  Then we can prove star is decidable for some maximum length using the above lemma.
+  And finally we can prove star is decidable using this final lemma.
+*)
+
+Definition elem_of_star_split (r: regex) (s: str) (index: nat) :=
   let prefix := firstn index s in
   let suffix := skipn index s in
   (prefix `elem` {{r}} /\ suffix `elem` {{star r}}).
@@ -255,7 +483,7 @@ Lemma star_lang_a_split_matches:
     s `elem` {{ star r }}
   <->
   (exists (index: nat) (index_range : 0 < index <= length s),
-    elem_of_split r s index
+    elem_of_star_split r s index
   ).
 Proof.
 intros.
@@ -265,7 +493,7 @@ split.
   + contradiction.
   + exists (length p).
     exists (prefix_is_gt_zero_and_leq p q s p_not_empty pqs).
-    unfold elem_of_split.
+    unfold elem_of_star_split.
     rewrite <- pqs.
     rewrite (firstn_length_prefix_is_prefix p q).
     rewrite (skipn_length_prefix_is_suffix p q).
@@ -284,7 +512,7 @@ Lemma star_lang_no_split_matches:
   s `notelem` {{ star r }}
   <->
   (forall (index: nat) (index_range : 0 < index <= length s),
-    not (elem_of_split r s index)
+    not (elem_of_star_split r s index)
   ).
 Proof.
 intros.
@@ -309,7 +537,7 @@ split.
   + set (prefix_is_gt_zero_and_leq p q s p_not_empty pqs) as p_range.
     set (split_of_not_star_r (length p) p_range) as specialized_split_of_not_star_r.
     apply specialized_split_of_not_star_r.
-    unfold elem_of_split.
+    unfold elem_of_star_split.
     split.
     * rewrite <- pqs.
       rewrite firstn_length_prefix_is_prefix.
@@ -326,11 +554,11 @@ Theorem star_lang_a_split_matches_or_no_split_matches:
       s `notelem` {{star r}}
   <->
       (exists (index: nat) (index_range : 0 < index <= length s),
-        elem_of_split r s index
+        elem_of_star_split r s index
       )
     \/
       (forall (index: nat) (index_range : 0 < index <= length s),
-        not (elem_of_split r s index) 
+        not (elem_of_star_split r s index) 
       ).
 Proof.
 intros.
@@ -338,71 +566,6 @@ destruct (star_lang_a_split_matches r s s_is_not_empty).
 destruct (star_lang_no_split_matches r s s_is_not_empty).
 (* This theorem clearly follows by the above theorems. *)
 split; intros decide; destruct decide; eauto.
-Qed.
-
-(* 
-  lift_index_and_max_len_from_disjunction
-  is used to lift the index and its max length bounds
-  out of a disjunction, by applying it on the goal.
-*)
-Theorem lift_index_and_max_len_from_disjunction
-  (P: nat -> Prop) (len: nat):
-  (forall (index : nat) (bounded_index: index <= len),
-      P index
-    \/ 
-      ~ (P index)
-  )
-  ->
-  (
-    (forall (index: nat) (bounded_index: index <= len),
-      ~ (P index)
-    )
-    \/
-    (exists (index: nat) (bounded_index: index <= len),
-      P index
-    )
-  ).
-Proof.
-intro lifted.
-induction len.
-- specialize lifted with (index := 0).
-  assert (0 <= 0) as ofcourse by lia.
-  destruct (lifted ofcourse) as [P0 | notP0].
-  + right.
-    exists 0.
-    split; assumption.
-  + left.
-    intros. 
-    assert (index = 0) as index0 by lia.
-    rewrite index0.
-    assumption.
-- assert (forall (index: nat) (bounded_index: index <= len), P index \/ ~ P index) as smaller_lifted.
-  + intros.
-    apply lifted.
-    lia.
-  + apply IHlen in smaller_lifted.
-    destruct smaller_lifted as [notPindex | Pindex].
-    * assert (S len <= S len) as slen_leq by lia.
-      destruct (lifted (S len) slen_leq) as [PSlen | notPSlen].
-      --- right.
-          exists (S len).
-          split; assumption.
-      --- left.
-          intros.
-          assert (forall (len: nat) (index: nat),
-            index <= S len -> index <= len \/ index = S len
-          ) as breakdown_leq by lia.
-          destruct (breakdown_leq len index bounded_index) as [leqlen | eqSlen].
-          +++ apply notPindex.
-              assumption.
-          +++ rewrite eqSlen.
-              assumption.
-    * right.
-      destruct Pindex as [index [bounded_index Pindex]].
-      exists index.
-      split.
-      --- lia.
-      --- assumption.
 Qed.
 
 (* 
@@ -497,7 +660,7 @@ induction len.
       lia.
     * apply IHlen in suffix_bound as decidable_suffix.
       clear IHlen max_length_S a_is_not_empty suffix_bound.
-      unfold elem_of_split.
+      unfold elem_of_star_split.
       destruct decidable_r as [prefix_elem | prefix_not_elem];
       destruct decidable_suffix as [suffix_elem | suffix_not_elem].
       --- left. auto.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -94,6 +94,157 @@ wreckit.
   * assumption.
 Qed.
 
+Definition no_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
+  forall (s1 s2: str),
+  s = s1 ++ s2 ->
+  length s1 <= n ->
+  ((s1 `notelem` {{ p }} \/ s2 `notelem` {{ q }})).
+
+Definition a_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
+  exists (s1 s2: str),
+  s = s1 ++ s2 /\
+  length s1 <= n /\
+  (s1 `elem` {{ p }} /\ s2 `elem` {{ q }}).
+
+Lemma denotation_concat_is_decidable_helper (p q: regex):
+  regex_is_decidable p ->
+  regex_is_decidable q ->
+  (forall (s: str) (n : nat),
+    no_splitting_is_an_elem_for_length p q s n
+    \/ a_splitting_is_an_elem_for_length p q s n
+  ).
+Proof.
+  intros Hdecp Hdecq s n.
+  induction n.
+  - (* case that s1 is empty string *)
+    destruct (Hdecp []) as [Hpmatches | Hpnomatch]; destruct (Hdecq s) as [Hqmatches | Hqnomatch].
+
+
+    2,3,4: left; intros s1 s2 Hconcat Hlen';
+      (* this could maybe use some refactoring.
+         But in principle it is simple: I want to do exactly this
+         for goals 2,3 and 4.
+       *)
+      (* now starts: we know what it is when it is split *)
+      assert (s1 = []) by (apply length_zero_or_smaller_string_is_empty; assumption);
+      assert (s2 = s) by (replace (s1 ++ s2) with s2 in Hconcat by (subst; auto);
+                          symmetry;
+                          assumption);
+      clear Hconcat;
+      clear Hlen';
+      subst;
+      try (now left);
+      try (now right).
+
+    + (* this is the case where in fact s matches q, [] matches p *)
+      right.
+      exists [].
+      exists s.
+      intros.
+      auto.
+
+  - (* induction step *)
+    set (l1 := firstn (S n) s).
+    set (l2 := skipn (S n) s).
+
+    (* case distinction on the induction hyptohesis (which is an or) *)
+    destruct IHn as [IHnAllNoMatch | IHnExistsMatch ].
+
+    (* The case where there is already a match with a smaller split. *)
+    2: {
+    right.
+    destruct IHnExistsMatch as [s1 IHn1].
+    destruct IHn1 as [s2 IHn].
+    exists s1. exists s2.
+    destruct IHn as [H0 [H1 [H2 H3]]].
+    repeat split; try assumption.
+    lia. }
+
+
+    (* If none of the earlier splits match. *)
+    destruct (Hdecp l1) as [Hpmatch | Hpnomatch].
+      destruct (Hdecq l2) as [Hqmatch | Hqnomatch ].
+
+      2,3: left;
+      intros s1 s2 Hconcat Hlen;
+      assert (length s1 <= n \/ length s1 = S n) as Hlen' by lia;
+      destruct Hlen' as [Hlen' | Hlen'];
+      try (apply IHnAllNoMatch; assumption); (* case length s1 <= n *)
+      try (
+          destruct (split_list s (S n) s1 s2 Hlen' Hconcat) as [Hfoo Hbar];
+
+          replace l1 with s1 in * by auto;
+          replace l2 with s2 in * by auto;
+          subst;
+          try (left; assumption);
+          try (right; assumption)).
+
+
+    + right. exists l1. exists l2. intros.
+
+      repeat split; try assumption.
+
+      * symmetry. apply firstn_skipn.
+      * apply firstn_le_length.
+
+
+        (* The proof below is the proof for 2,3, but written with periods instead of semicolons...
+           the periods are easier to step through, and it is also how I wrote it.
+           But as I've said above, I don't know how to do that for 2 goals at the same time.
+
+         *)
+        (*
+    +
+      left.
+      intros s1 s2 Hconcat Hlen.
+
+      assert (length s1 <= n \/ length s1 = S n) as Hlen' by lia.
+      destruct Hlen' as [Hlen' | Hlen'].
+
+      * apply IHnAllNoMatch; assumption. (* case length s1 <= n *)
+      * destruct (split_string_lemma s (S n) s1 s2 Hlen' Hconcat) as [Hfoo Hbar].
+
+        replace l1 with s1 in * by auto.
+        replace l2 with s2 in * by auto.
+        subst.
+        try (left; assumption).
+        try (right; assumption).
+*)
+
+Qed.
+
+Lemma denotation_concat_is_decidable (p q: regex):
+  regex_is_decidable p ->
+  regex_is_decidable q ->
+  regex_is_decidable (concat p q).
+Proof.
+  intros Hdecp Hdecq.
+  unfold regex_is_decidable.
+  intro s.
+  destruct (denotation_concat_is_decidable_helper p q Hdecp Hdecq s (length s))
+  as [HAllDontMatch | HExistsMatch].
+
+  - right.
+    unfold not.
+    intro HmatchContr.
+    destruct HmatchContr.
+    symmetry in H.
+
+    set (Hlen := prefix_leq_length s p0 q0 H).
+    unfold no_splitting_is_an_elem_for_length in HAllDontMatch.
+    specialize HAllDontMatch with p0 q0.
+    destruct (HAllDontMatch H Hlen); auto.
+
+  - left.
+    destruct HExistsMatch as [s1 [s2 [Hconcat [Hlen [Hmatchp Hmatchq]]]]].
+    symmetry in Hconcat.
+    destruct_concat_lang.
+    exists s1.
+    exists s2.
+    exists Hconcat.
+    split; assumption.
+Qed.
+
 Definition elem_of_split (r: regex) (s: str) (index: nat) :=
   let prefix := firstn index s in
   let suffix := skipn index s in
@@ -364,214 +515,6 @@ intro Hr.
 intro s.
 apply (denotation_star_is_decidable_bounded_len r (length s) Hr).
 lia.
-Qed.
-
-Definition no_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
-  forall (s1 s2: str),
-  s = s1 ++ s2 ->
-  length s1 <= n ->
-  ((s1 `notelem` {{ p }} \/ s2 `notelem` {{ q }})).
-
-Definition a_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
-  exists (s1 s2: str),
-  s = s1 ++ s2 /\
-  length s1 <= n /\
-  (s1 `elem` {{ p }} /\ s2 `elem` {{ q }}).
-
-Lemma denotation_concat_is_decidable_helper (p q: regex):
-  regex_is_decidable p ->
-  regex_is_decidable q ->
-  (forall (s: str) (n : nat),
-    no_splitting_is_an_elem_for_length p q s n
-    \/ a_splitting_is_an_elem_for_length p q s n
-  ).
-Proof.
-  intros Hdecp Hdecq s n.
-  induction n.
-  - (* case that s1 is empty string *)
-    destruct (Hdecp []) as [Hpmatches | Hpnomatch]; destruct (Hdecq s) as [Hqmatches | Hqnomatch].
-
-
-    2,3,4: left; intros s1 s2 Hconcat Hlen';
-      (* this could maybe use some refactoring.
-         But in principle it is simple: I want to do exactly this
-         for goals 2,3 and 4.
-       *)
-      (* now starts: we know what it is when it is split *)
-      assert (s1 = []) by (apply length_zero_or_smaller_string_is_empty; assumption);
-      assert (s2 = s) by (replace (s1 ++ s2) with s2 in Hconcat by (subst; auto);
-                          symmetry;
-                          assumption);
-      clear Hconcat;
-      clear Hlen';
-      subst;
-      try (now left);
-      try (now right).
-
-    + (* this is the case where in fact s matches q, [] matches p *)
-      right.
-      exists [].
-      exists s.
-      intros.
-      auto.
-
-  - (* induction step *)
-    set (l1 := firstn (S n) s).
-    set (l2 := skipn (S n) s).
-
-    (* case distinction on the induction hyptohesis (which is an or) *)
-    destruct IHn as [IHnAllNoMatch | IHnExistsMatch ].
-
-    (* The case where there is already a match with a smaller split. *)
-    2: {
-    right.
-    destruct IHnExistsMatch as [s1 IHn1].
-    destruct IHn1 as [s2 IHn].
-    exists s1. exists s2.
-    destruct IHn as [H0 [H1 [H2 H3]]].
-    repeat split; try assumption.
-    lia. }
-
-
-    (* If none of the earlier splits match. *)
-    destruct (Hdecp l1) as [Hpmatch | Hpnomatch].
-      destruct (Hdecq l2) as [Hqmatch | Hqnomatch ].
-
-      2,3: left;
-      intros s1 s2 Hconcat Hlen;
-      assert (length s1 <= n \/ length s1 = S n) as Hlen' by lia;
-      destruct Hlen' as [Hlen' | Hlen'];
-      try (apply IHnAllNoMatch; assumption); (* case length s1 <= n *)
-      try (
-          destruct (split_list s (S n) s1 s2 Hlen' Hconcat) as [Hfoo Hbar];
-
-          replace l1 with s1 in * by auto;
-          replace l2 with s2 in * by auto;
-          subst;
-          try (left; assumption);
-          try (right; assumption)).
-
-
-    + right. exists l1. exists l2. intros.
-
-      repeat split; try assumption.
-
-      * symmetry. apply firstn_skipn.
-      * apply firstn_le_length.
-
-
-        (* The proof below is the proof for 2,3, but written with periods instead of semicolons...
-           the periods are easier to step through, and it is also how I wrote it.
-           But as I've said above, I don't know how to do that for 2 goals at the same time.
-
-         *)
-        (*
-    +
-      left.
-      intros s1 s2 Hconcat Hlen.
-
-      assert (length s1 <= n \/ length s1 = S n) as Hlen' by lia.
-      destruct Hlen' as [Hlen' | Hlen'].
-
-      * apply IHnAllNoMatch; assumption. (* case length s1 <= n *)
-      * destruct (split_string_lemma s (S n) s1 s2 Hlen' Hconcat) as [Hfoo Hbar].
-
-        replace l1 with s1 in * by auto.
-        replace l2 with s2 in * by auto.
-        subst.
-        try (left; assumption).
-        try (right; assumption).
-*)
-
-Qed.
-
-Lemma denotation_concat_is_decidable (p q: regex):
-  regex_is_decidable p ->
-  regex_is_decidable q ->
-  regex_is_decidable (concat p q).
-Proof.
-  intros Hdecp Hdecq.
-  unfold regex_is_decidable.
-  intro s.
-  destruct (denotation_concat_is_decidable_helper p q Hdecp Hdecq s (length s))
-  as [HAllDontMatch | HExistsMatch].
-
-  - right.
-    unfold not.
-    intro HmatchContr.
-    destruct HmatchContr.
-    symmetry in H.
-
-    set (Hlen := prefix_leq_length s p0 q0 H).
-    unfold no_splitting_is_an_elem_for_length in HAllDontMatch.
-    specialize HAllDontMatch with p0 q0.
-    destruct (HAllDontMatch H Hlen); auto.
-
-  - left.
-    destruct HExistsMatch as [s1 [s2 [Hconcat [Hlen [Hmatchp Hmatchq]]]]].
-    symmetry in Hconcat.
-    destruct_concat_lang.
-    exists s1.
-    exists s2.
-    exists Hconcat.
-    split; assumption.
-Qed.
-
-Lemma denotation_concat_is_decidable_for_empty_string (p q: regex):
-  [] `elem` {{ p }} \/ [] `notelem` {{ p }} ->
-  [] `elem` {{ q }} \/ [] `notelem` {{ q }} ->
-  [] `elem` {{ concat p q }} \/ [] `notelem` {{ concat p q }}.
-Proof.
-intros.
-wreckit.
-- left.
-  destruct_concat_lang.
-  exists [].
-  exists [].
-  exists eq_refl.
-  split; assumption.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  listerine.
-  contradiction.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  listerine.
-  contradiction.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  listerine.
-  contradiction.
-Qed.
-
-Lemma denotation_star_is_decidable_for_empty_string (r: regex):
-  [] `elem` {{ star r }} \/ [] `notelem` {{ star r }}.
-Proof.
-left.
-constructor.
-Qed.
-
-Lemma denotation_is_decidable_on_empty_string (r: regex):
-  [] `elem` {{ r }} \/ [] `notelem` {{ r }}.
-Proof.
-intros.
-induction r.
-- apply denotation_emptyset_is_decidable.
-- apply denotation_lambda_is_decidable.
-- apply denotation_symbol_is_decidable.
-- apply denotation_concat_is_decidable_for_empty_string.
-  + assumption.
-  + assumption.
-- apply denotation_star_is_decidable_for_empty_string.
-- apply denotation_nor_is_decidable.
-  + assumption.
-  + assumption.
 Qed.
 
 Theorem denotation_is_decidable (r: regex) (s: str):

--- a/src/CoqStock/List.v
+++ b/src/CoqStock/List.v
@@ -189,11 +189,27 @@ Proof.
 auto with list.
 Qed.
 
+(* TODO: Help Wanted
+Cannot infer the implicit parameter A of skipn_length_prefix_is_suffix
+whose type is "Type".
+Hint Rewrite
+  skipn_length_prefix_is_suffix
+  : list.
+*)
+
 Lemma firstn_length_prefix_is_prefix {A: Type} (prefix suffix: list A):
   firstn (length prefix) (prefix ++ suffix) = prefix.
 Proof.
 auto with list.
 Qed.
+
+(* TODO: Help Wanted
+Cannot infer the implicit parameter A of firstn_length_prefix_is_prefix
+whose type is "Type".
+Hint Rewrite
+  firstn_length_prefix_is_prefix
+  : list.
+*)
 
 Theorem prefix_length_leq:
   forall {A: Type} (prefix suffix list: list A),


### PR DESCRIPTION
Now that we have proven decidability, I am cleaning it up to make it approachable.
This is just some initial steps towards that goal:

- Renamed some theorems and used more names in proofs.
- Moved a few things around, so that proofs are always in order, emptyset, lambda, ..., concat, star.
- Prove concat in the same cleaned up manner as star, see newly added comments for details

For a more readable diff, see the commits separately