### PR TITLE
pair programming results from past two sessions

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -41,6 +41,7 @@ src/Brzozowski/ConcatLang.v
 src/Brzozowski/Derive.v
 src/Brzozowski/ExampleR.v
 src/Brzozowski/Language.v
+src/Brzozowski/LogicOp.v
 src/Brzozowski/Regex.v
 src/Brzozowski/Setoid.v
 src/Brzozowski/Simplify.v

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -7,8 +7,10 @@ Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.ConcatLang.
+Require Import Brzozowski.Decidable.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Language.
+Require Import Brzozowski.LogicOp.
 
 (*
     **Definition 3.2.**
@@ -373,6 +375,31 @@ apply delta_and_r_emptyset.
 assumption.
 Qed.
 
+Theorem delta_and_emptyset_either: forall (p q: regex),
+    delta p emptyset \/
+    delta q emptyset ->
+    delta (and p q) emptyset.
+Proof.
+intros.
+destruct H.
+- constructor.
+  untie.
+  invs H0.
+  wreckit.
+  apply L.
+  invs H.
+  constructor.
+  split; assumption.
+- constructor.
+  untie.
+  invs H0.
+  wreckit.
+  apply R.
+  invs H.
+  constructor.
+  split; assumption.
+Qed.
+
 Theorem delta_not_emptyset: forall (r: regex),
     delta r lambda ->
     delta (complement r) emptyset.
@@ -595,144 +622,35 @@ induction r.
   auto.
 Qed.
 
+Theorem delta_only_emptyset_or_lambda (r: regex):
+  delta r emptyset \/ delta r lambda.
+Proof.
+specialize denotation_is_decidable with (r := r) (s := []).
+intros.
+destruct H.
+- right. constructor. assumption.
+- left. constructor. assumption.
+Qed.
+
 (*
 delta_split_lambda_or splits a regular expression into
 a possible lambda and the regular expression that does not match lambda.
 This theorem is needed for finding the derive function for the concat operator.
 Let:
-  P = delta_def(P) or P_0
-  where delta_def(P_0) = emptyset
+  R = delta_def(R) or R'
+  where delta_def(R') = emptyset
 =>
 Let:
-  R = P or Q
-  P = delta_def(R)
-  where delta_def(Q) = emptyset
+  R = E or R'
+  E = delta_def(R)
+  where delta_def(R') = emptyset
 *)
 Theorem delta_split_lambda_or (r: regex):
   exists
-    (p q: regex),
-    delta r p /\
-    delta q emptyset /\
-    {{r}} {<->} {{or p q}}.
+    (e r': regex),
+    delta r e /\
+    delta r' emptyset /\
+    {{r}} {<->} {{or e r'}}.
 Proof.
-induction r.
-- exists emptyset.
-  exists emptyset.
-  split.
-  apply delta_emptyset_is_emptyset.
-  split.
-  apply delta_emptyset_is_emptyset.
-  split; intros.
-  + constructor.
-    wreckit.
-    untie.
-  + invs H.
-    wreckit.
-    exfalso.
-    apply L.
-    constructor.
-    wreckit.
-    untie.
-- exists lambda.
-  exists emptyset.
-  split.
-  apply delta_lambda_is_lambda.
-  split.
-  apply delta_emptyset_is_emptyset.
-  split; intros.
-  constructor.
-  split.
-  untie.
-  invs H0.
-  wreckit.
-  apply L.
-  assumption.
-  untie.
-  invs H0.
-  wreckit.
-  apply L.
-  assumption.
-  invs H.
-  wreckit.
-  destruct s.
-  + constructor.
-  + exfalso.
-    apply L.
-    constructor.
-    wreckit.
-    untie.
-    invs H.
-    untie.
-- exists emptyset.
-  exists (symbol a).
-  split.
-  apply delta_symbol_is_emptyset.
-  split.
-  apply delta_symbol_is_emptyset.
-  split.
-  intros.
-  constructor.
-  split.
-  untie.
-  invs H0.
-  wreckit.
-  apply R.
-  assumption.
-  untie.
-  invs H0.
-  wreckit.
-  contradiction.
-  intros.
-  invs H.
-  wreckit.
-  destruct s.
-  exfalso.
-  apply L.
-  constructor.
-  wreckit.
-  untie.
-  untie.
-  invs H.
-  destruct s.
-  + destruct a, a0.
-    * constructor.
-    * exfalso.
-      apply L.
-      constructor.
-      wreckit.
-      untie.
-      untie.
-      invs H.
-    * exfalso.
-      apply L.
-      constructor.
-      wreckit.
-      untie.
-      untie.
-      invs H.
-    * constructor.
-  + exfalso.
-    apply L.
-    constructor.
-    wreckit.
-    untie.
-    untie.
-    invs H.
-- wreckit.
-  exists (delta_and x1 x).
-  exists (concat x2 x0). (* or maybe (concat x2 r2) *)
-  apply delta_implies_delta_def in L1.
-  apply delta_implies_delta_def in L2.
-  apply delta_implies_delta_def in L.
-  apply delta_implies_delta_def in L0.
-  split.
-  + apply delta_def_implies_delta.
-    subst.
-    dubstep delta_def.
-    reflexivity.
-  + admit.
-- admit.
-- admit.
 (* TODO: Help Wanted *)
 Abort.
-

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -8,6 +8,7 @@ Require Import CoqStock.List.
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Delta.
+Require Import Brzozowski.LogicOp.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Setoid.
 Require Import Brzozowski.Language.
@@ -484,16 +485,24 @@ Lemma commutes_a_concat: forall (a : alphabet) (p q: regex)
     {{derive_def (concat p q) a}}
   ).
 Proof.
+intros a p q.
+simpl derive_def.
+set (dp := derive_def p a).
+set (dq := derive_def q a).
 intros.
-split.
-- apply concat_lang_a_impl_def;
-    unfold "{<->}" in *;
-    unfold "{->}" in *;
-    intros s0.
-  + apply (IHp s0).
-  + apply (IHq s0).
-- (* TODO: Help Wanted *)
-Admitted.
+case (delta_def p).
+unfold derive_lang_a.
+rewrite or_denotes_or_lang.
+specialize or_lang_is_disj with (
+  p := concat (derive_def p a) q
+) (
+  q := concat (delta_def p) (derive_def q a)
+) as or_disj.
+unfold lang_iff.
+intros.
+specialize or_disj with (s := s).
+(* TODO: Help Wanted *)
+Abort.
 
 (*
   Finally we have
@@ -522,7 +531,6 @@ Admitted.
 
   which is rule (3.6).
 *)
-
 Lemma commutes_a_star: forall (a : alphabet) (r : regex)
   (IH: derive_lang_a {{r}} a {<->} {{derive_def r a}}),
   (
@@ -532,7 +540,7 @@ Lemma commutes_a_star: forall (a : alphabet) (r : regex)
   ).
 Proof.
 (* TODO: Help Wanted *)
-Admitted.
+Abort.
 
 Theorem derive_commutes_a: forall (r: regex) (a: alphabet),
   derive_lang_a {{ r }} a
@@ -543,15 +551,21 @@ induction r; intros.
 - apply commutes_a_emptyset.
 - apply commutes_a_lambda.
 - apply commutes_a_symbol.
-- apply commutes_a_concat.
+- (*TODO Help Wanted
+    Proof theorem commutes_a_concat and then apply it.
+  apply commutes_a_concat.
   + apply IHr1.
   + apply IHr2.
-- apply commutes_a_star.
+*) admit.
+- (*TODO Help Wanted
+Proof theorem commutes_a_concat and then apply it.
+  apply commutes_a_star.
   + apply IHr.
+*) admit.
 - apply commutes_a_nor.
   + apply IHr1.
   + apply IHr2.
-Qed.
+Abort.
 
 Definition derive_defs (r: regex) (s: str) : regex :=
   fold_left derive_def s r.
@@ -823,5 +837,29 @@ Theorem derive_commutes: forall (r: regex) (s: str),
   {<->}
   {{ derive_defs r s }}.
 Proof.
-(* TODO: Help Wanted *)
+(* TODO: Help Wanted
+   Finish proving derive_commutes_a
+   and apply the following proof script:
+set derive_commutes_a as commutes.
+intros.
+generalize dependent r.
+induction s.
+- unfold derive_lang.
+  cbn.
+  intros.
+  reflexivity.
+- cbn.
+  intros.
+  fold (derive_defs (derive_def r a) s).
+  specialize IHs with (r := (derive_def r a)).
+  rewrite <- IHs.
+  specialize commutes with (r := r) (a := a).
+  unfold lang_iff in *.
+  intros.
+  unfold derive_lang in *.
+  unfold elem.
+  specialize commutes with (s ++ s0).
+  rewrite commutes.
+  reflexivity.
+*)
 Abort.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -5,9 +5,10 @@ Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
-Require Import Brzozowski.Regex.
 Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
+Require Import Brzozowski.LogicOp.
+Require Import Brzozowski.Regex.
 
 (*
 The introduction of arbitrary Boolean functions enriches the language of regular expressions.

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -108,6 +108,3 @@ Fixpoint denote_regex (r: regex): lang :=
   end
 where "{{ r }}" := (denote_regex r).
 
-Definition not_lang (R: lang) : lang :=
-  nor_lang R R.
-

--- a/src/Brzozowski/LogicOp.v
+++ b/src/Brzozowski/LogicOp.v
@@ -120,7 +120,7 @@ Qed.
 
 Theorem or_lang_is_disj:
   forall (p q: regex) (s: str),
-  s `elem` or_lang {{p}} {{q}} <-> s `elem` {{p}} \/ s `elem` {{q}}.
+  s \in or_lang {{p}} {{q}} <-> s \in {{p}} \/ s \in {{q}}.
 Proof.
 intros.
 split.
@@ -141,7 +141,7 @@ Qed.
 
 Theorem or_is_disj:
   forall (p q: regex) (s: str),
-  s `elem` {{ or p q }} <-> s `elem` {{p}} \/ s `elem` {{q}}.
+  s \in {{ or p q }} <-> s \in {{p}} \/ s \in {{q}}.
 Proof.
 intros.
 specialize or_denotes_or_lang with (p := p) (q := q).

--- a/src/Brzozowski/LogicOp.v
+++ b/src/Brzozowski/LogicOp.v
@@ -1,0 +1,154 @@
+Require Import Coq.Setoids.Setoid.
+
+Require Import CoqStock.Untie.
+Require Import CoqStock.WreckIt.
+
+Require Import Brzozowski.Decidable.
+Require Import Brzozowski.Language.
+Require Import Brzozowski.Regex.
+Require Import Brzozowski.Setoid.
+
+(* We chose to include `nor`, since it can represent any possible boolean expression,
+   which is one of the selling points of Brzozowski's derivatives for regular expressions.
+*)
+
+Definition complement (r: regex) : regex :=
+  nor r r.
+
+Definition and (r s: regex) : regex :=
+  nor (nor r r) (nor s s).
+
+Definition or (r s: regex) : regex :=
+  nor (nor r s) (nor r s).
+
+Definition xor (r s: regex) : regex :=
+  or (and r (complement s)) (and (complement r) s).
+
+(* I matches all strings *)
+Definition I: regex :=
+  complement (emptyset).
+
+Definition not_lang (R: lang) : lang :=
+  nor_lang R R.
+
+Definition and_lang (P Q: lang) : lang :=
+  nor_lang (nor_lang P P) (nor_lang Q Q).
+
+Definition or_lang (P Q: lang) : lang :=
+  nor_lang (nor_lang P Q) (nor_lang P Q).
+
+Lemma denote_regex_or_step:
+  forall (p q: regex),
+  {{or p q}} {<->} or_lang {{p}} {{q}}.
+Proof.
+  intros.
+  cbn.
+  unfold or_lang.
+  reflexivity.
+Qed.
+
+Lemma denote_regex_and_step:
+  forall (p q: regex),
+  {{and p q}} {<->} and_lang {{p}} {{q}}.
+Proof.
+  intros.
+  cbn.
+  unfold and_lang.
+  reflexivity.
+Qed.
+
+Lemma denote_regex_complement_step:
+  forall (r: regex),
+  {{complement r}} {<->} not_lang {{r}}.
+Proof.
+  intros.
+  cbn.
+  unfold not_lang.
+  reflexivity.
+Qed.
+
+Add Parametric Morphism: or_lang
+  with signature lang_iff ==> lang_iff ==> lang_iff as or_lang_morph.
+Proof.
+intros.
+unfold or_lang.
+rewrite H.
+rewrite H0.
+reflexivity.
+Qed.
+
+Existing Instance or_lang_morph_Proper.
+
+Add Parametric Morphism: and_lang
+  with signature lang_iff ==> lang_iff ==> lang_iff as and_lang_morph.
+Proof.
+intros.
+unfold and_lang.
+rewrite H.
+rewrite H0.
+reflexivity.
+Qed.
+
+Existing Instance and_lang_morph_Proper.
+
+Add Parametric Morphism: not_lang
+  with signature lang_iff ==> lang_iff as not_lang_morph.
+Proof.
+intros.
+unfold not_lang.
+rewrite H.
+reflexivity.
+Qed.
+
+Existing Instance not_lang_morph_Proper.
+
+Theorem or_denotes_or_lang:
+  forall (p q: regex),
+  {{or p q}} {<->} or_lang {{p}} {{q}}.
+Proof.
+intros.
+split.
+- intros.
+  cbn in *.
+  unfold or_lang.
+  assumption.
+- intros.
+  cbn in *.
+  unfold or_lang in H.
+  assumption.
+Qed.
+
+Theorem or_lang_is_disj:
+  forall (p q: regex) (s: str),
+  s `elem` or_lang {{p}} {{q}} <-> s `elem` {{p}} \/ s `elem` {{q}}.
+Proof.
+intros.
+split.
+- intros.
+  destruct H.
+  destruct H.
+  clear H0.
+  unfold elem in H.
+  destruct (denotation_is_decidable p s);
+  destruct (denotation_is_decidable q s);
+  auto.
+  + exfalso. apply H. constructor. split; assumption.
+- intros.
+  constructor.
+  split; destruct H; unfold elem; untie;
+  destruct H0; wreckit; contradiction.
+Qed.
+
+Theorem or_is_disj:
+  forall (p q: regex) (s: str),
+  s `elem` {{ or p q }} <-> s `elem` {{p}} \/ s `elem` {{q}}.
+Proof.
+intros.
+specialize or_denotes_or_lang with (p := p) (q := q).
+intros or_is_or_lang.
+unfold lang_iff in or_is_or_lang.
+specialize or_is_or_lang with (s := s).
+rewrite or_is_or_lang.
+rewrite or_lang_is_disj.
+reflexivity.
+Qed.

--- a/src/Brzozowski/Regex.v
+++ b/src/Brzozowski/Regex.v
@@ -21,23 +21,3 @@ Inductive regex :=
   *)
   | nor : regex -> regex -> regex
   .
-
-(* We chose to include `nor`, since it can represent any possible boolean expression,
-   which is one of the selling points of Brzozowski's derivatives for regular expressions.
-*)
-
-Definition complement (r: regex) : regex :=
-  nor r r.
-
-Definition and (r s: regex) : regex :=
-  nor (nor r r) (nor s s).
-
-Definition or (r s: regex) : regex :=
-  nor (nor r s) (nor r s).
-
-Definition xor (r s: regex) : regex :=
-  or (and r (complement s)) (and (complement r) s).
-
-(* I matches all strings *)
-Definition I: regex :=
-    complement (emptyset).

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -12,6 +12,7 @@ Require Import CoqStock.WreckIt.
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
+Require Import Brzozowski.LogicOp.
 Require Import Brzozowski.Regex.
 
 (*


### PR DESCRIPTION
We have created LogicOp.v which contains proofs for `and`, `or` and `not`.
We should consider whether we should include `or` as an operator, instead of relying on `nor`, to define all operators, since `or` is used inside `concat` and so also `star`.  It is something we can discuss in a following session.

We have also shown that if we prove that the square commutes for deriving a single character then it commutes for strings. To complete this commuting square proof, we need to prove it for concat and star of a single character.