### PR TITLE
Replace `elem` with \in and `notelem` with \notin

### DIFF
--- a/src/Brzozowski/ConcatLang.v
+++ b/src/Brzozowski/ConcatLang.v
@@ -29,8 +29,8 @@ Inductive concat_lang_ex (P Q: lang): lang :=
       (p: str)
       (q: str)
       (pqs: p ++ q = s),
-      p `elem` P /\
-      q `elem` Q
+      p \in P /\
+      q \in Q
     ) ->
     concat_lang_ex P Q s
   .
@@ -71,8 +71,8 @@ Ltac destruct_concat_lang :=
 (* example_destruct_concat_lang shows how the destruct_concat_lang can be used. *)
 Example example_destruct_concat_lang:
   forall (p q: regex),
-  [] `elem` {{p}} /\ [] `elem` {{q}} ->
-  [] `elem` {{concat p q}}.
+  [] \in {{p}} /\ [] \in {{q}} ->
+  [] \in {{concat p q}}.
 Proof.
 intros.
 destruct_concat_lang.

--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -2,7 +2,7 @@
 In this module we prove the denotation of regular expressions is decidable, using:
 ```
 Theorem denotation_is_decidable (r: regex) (s: str):
-  s `elem` {{ r }} \/ s `notelem` {{ r }}.
+  s \in {{ r }} \/ s \notin {{ r }}.
 ```
 *)
 
@@ -21,17 +21,17 @@ Require Import Brzozowski.Language.
 Require Import Brzozowski.Regex.
 
 Definition regex_is_decidable (r: regex) :=
-  (forall s: str, s `elem` {{r}} \/ s `notelem` {{r}}).
+  (forall s: str, s \in {{r}} \/ s \notin {{r}}).
 
 Lemma denotation_emptyset_is_decidable (s: str):
-  s `elem` {{ emptyset }} \/ s `notelem` {{ emptyset }}.
+  s \in {{ emptyset }} \/ s \notin {{ emptyset }}.
 Proof.
 right.
 untie.
 Qed.
 
 Lemma denotation_lambda_is_decidable (s: str):
-  s `elem` {{ lambda }} \/ s `notelem` {{ lambda }}.
+  s \in {{ lambda }} \/ s \notin {{ lambda }}.
 Proof.
 destruct s.
 - left. constructor.
@@ -39,7 +39,7 @@ destruct s.
 Qed.
 
 Lemma denotation_symbol_is_decidable (s: str) (a: alphabet):
-  s `elem` {{ symbol a }} \/ s `notelem` {{ symbol a }}.
+  s \in {{ symbol a }} \/ s \notin {{ symbol a }}.
 Proof.
 destruct s.
 - right. untie. invs H.
@@ -65,9 +65,9 @@ destruct s.
 Qed.
 
 Lemma denotation_nor_is_decidable (p q: regex) (s: str):
-  s `elem` {{ p }} \/ s `notelem` {{ p }} ->
-  s `elem` {{ q }} \/ s `notelem` {{ q }} ->
-  s `elem` {{ nor p q }} \/ s `notelem` {{ nor p q }}.
+  s \in {{ p }} \/ s \notin {{ p }} ->
+  s \in {{ q }} \/ s \notin {{ q }} ->
+  s \in {{ nor p q }} \/ s \notin {{ nor p q }}.
 Proof.
 simpl.
 intros.
@@ -111,11 +111,11 @@ Qed.
 Definition elem_of_concat_split (p q: regex) (s: str) (index: nat) :=
   let prefix := firstn index s in
   let suffix := skipn index s in
-  (prefix `elem` {{p}} /\ suffix `elem` {{q}}).
+  (prefix \in {{p}} /\ suffix \in {{q}}).
 
 Lemma concat_lang_a_split_matches:
   forall (P Q: regex) (s: str),
-    s `elem` {{ concat P Q }}
+    s \in {{ concat P Q }}
   <->
   (exists (index: nat) (index_range : index <= length s),
     elem_of_concat_split P Q s index
@@ -152,7 +152,7 @@ Qed.
 
 Lemma concat_lang_no_split_matches:
   forall (P Q: regex) (s: str),
-  s `notelem` {{ concat P Q }}
+  s \notin {{ concat P Q }}
   <->
   (forall (index: nat) (index_range : index <= length s),
     not (elem_of_concat_split P Q s index)
@@ -185,9 +185,9 @@ Qed.
 
 Theorem concat_lang_a_split_matches_or_no_split_matches:
   forall (P Q: regex) (s: str),
-      s `elem` {{concat P Q}}
+      s \in {{concat P Q}}
     \/
-      s `notelem` {{concat P Q}}
+      s \notin {{concat P Q}}
   <->
       (exists (index: nat) (index_range : index <= length s),
         elem_of_concat_split P Q s index
@@ -273,7 +273,7 @@ Lemma denotation_concat_is_decidable_bounded_len
   (forall
     (s: str)
     (bounded_len: length s <= len),
-    (s `elem` {{concat P Q}} \/ s `notelem` {{concat P Q}})
+    (s \in {{concat P Q}} \/ s \notin {{concat P Q}})
   ).
 Proof.
 intros.
@@ -311,13 +311,13 @@ Definition no_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
   forall (s1 s2: str),
   s = s1 ++ s2 ->
   length s1 <= n ->
-  ((s1 `notelem` {{ p }} \/ s2 `notelem` {{ q }})).
+  ((s1 \notin {{ p }} \/ s2 \notin {{ q }})).
 
 Definition a_splitting_is_an_elem_for_length (p q: regex) (s: str) (n: nat) :=
   exists (s1 s2: str),
   s = s1 ++ s2 /\
   length s1 <= n /\
-  (s1 `elem` {{ p }} /\ s2 `elem` {{ q }}).
+  (s1 \in {{ p }} /\ s2 \in {{ q }}).
 
 Lemma denotation_concat_is_decidable_helper (p q: regex):
   regex_is_decidable p ->
@@ -476,11 +476,11 @@ Qed.
 Definition elem_of_star_split (r: regex) (s: str) (index: nat) :=
   let prefix := firstn index s in
   let suffix := skipn index s in
-  (prefix `elem` {{r}} /\ suffix `elem` {{star r}}).
+  (prefix \in {{r}} /\ suffix \in {{star r}}).
 
 Lemma star_lang_a_split_matches:
   forall (r: regex) (s: str) (s_is_not_empty: s <> []),
-    s `elem` {{ star r }}
+    s \in {{ star r }}
   <->
   (exists (index: nat) (index_range : 0 < index <= length s),
     elem_of_star_split r s index
@@ -509,7 +509,7 @@ Qed.
 
 Lemma star_lang_no_split_matches:
   forall (r: regex) (s: str) (s_is_not_empty: s <> []),
-  s `notelem` {{ star r }}
+  s \notin {{ star r }}
   <->
   (forall (index: nat) (index_range : 0 < index <= length s),
     not (elem_of_star_split r s index)
@@ -549,9 +549,9 @@ Qed.
 
 Theorem star_lang_a_split_matches_or_no_split_matches:
   forall (r: regex) (s: str) (s_is_not_empty: s <> []),
-      s `elem` {{star r}}
+      s \in {{star r}}
     \/
-      s `notelem` {{star r}}
+      s \notin {{star r}}
   <->
       (exists (index: nat) (index_range : 0 < index <= length s),
         elem_of_star_split r s index
@@ -630,7 +630,7 @@ Lemma denotation_star_is_decidable_bounded_len
   (forall
     (s: str)
     (bounded_len: length s <= len),
-    (s `elem` {{star r}} \/ s `notelem` {{star r}})
+    (s \in {{star r}} \/ s \notin {{star r}})
   ).
 Proof.
 intros.
@@ -681,7 +681,7 @@ lia.
 Qed.
 
 Theorem denotation_is_decidable (r: regex) (s: str):
-  s `elem` {{ r }} \/ s `notelem` {{ r }}.
+  s \in {{ r }} \/ s \notin {{ r }}.
 Proof.
 generalize dependent s.
 induction r.

--- a/src/Brzozowski/Delta.v
+++ b/src/Brzozowski/Delta.v
@@ -24,10 +24,10 @@ Require Import Brzozowski.Language.
 
 Inductive delta: regex -> regex -> Prop :=
   | delta_lambda (r: regex):
-    [] `elem` {{r}} ->
+    [] \in {{r}} ->
     delta r lambda
   | delta_emptyset (r: regex):
-    [] `notelem` {{r}} ->
+    [] \notin {{r}} ->
     delta r emptyset
     .
 

--- a/src/Brzozowski/Derive.v
+++ b/src/Brzozowski/Derive.v
@@ -19,7 +19,7 @@ the derivative of $R$ with respect to $s$ is denoted by $D_s R$ and is
 $D_s R = \{t | s.t \in R \}$.
 *)
 Definition derive_lang (R: lang) (s: str) (t: str): Prop :=
-  (s ++ t) `elem` R.
+  (s ++ t) \in R.
 
 (* Part of THEOREM 3.2
    For completeness, if s = \lambda, then D_[] R = R
@@ -30,10 +30,10 @@ Proof.
 intros.
 unfold derive_lang.
 cbn.
-unfold "`elem`".
+unfold "\in".
 unfold "{<->}".
 intros.
-unfold "`elem`".
+unfold "\in".
 easy.
 Qed.
 
@@ -61,12 +61,12 @@ Proof.
 intros.
 split.
 - unfold derive_lang.
-  unfold "`elem`".
+  unfold "\in".
   intros.
   rewrite app_assoc.
   assumption.
 - unfold derive_lang.
-  unfold "`elem`".
+  unfold "\in".
   intros.
   rewrite app_assoc in H.
   assumption.
@@ -80,12 +80,12 @@ Proof.
 intros.
 split.
 - unfold derive_lang.
-  unfold "`elem`".
+  unfold "\in".
   intros.
   cbn in *.
   assumption.
 - unfold derive_lang.
-  unfold "`elem`".
+  unfold "\in".
   intros.
   cbn in *.
   assumption.
@@ -95,7 +95,7 @@ Qed.
 D_a R = { t | a.t \in R}
 *)
 Definition derive_lang_a (R: lang) (a: alphabet) (t: str): Prop :=
-  (a :: t) `elem` R.
+  (a :: t) \in R.
 
 Theorem derive_lang_a_single: forall (R: lang) (a: alphabet),
   derive_lang R [a] {<->} derive_lang_a R a.
@@ -110,27 +110,27 @@ easy.
 Qed.
 
 Theorem derive_lang_single: forall (R: lang) (a: alphabet) (s s0: str),
-  s0 `elem` derive_lang R (a :: s) <->
-  (s ++ s0) `elem` derive_lang R (a :: []).
+  s0 \in derive_lang R (a :: s) <->
+  (s ++ s0) \in derive_lang R (a :: []).
 Proof.
 intros.
 split;
   intros;
   unfold derive_lang in *;
-  unfold "`elem`" in *;
+  unfold "\in" in *;
   listerine;
   assumption.
 Qed.
 
 Theorem derive_lang_double: forall (R: lang) (a a0: alphabet) (s s0: str),
-  s0 `elem` derive_lang R (a :: a0 :: s) <->
-  (s ++ s0) `elem` derive_lang R (a :: a0 :: []).
+  s0 \in derive_lang R (a :: a0 :: s) <->
+  (s ++ s0) \in derive_lang R (a :: a0 :: []).
 Proof.
 intros.
 split;
   intros;
   unfold derive_lang in *;
-  unfold "`elem`" in *;
+  unfold "\in" in *;
   listerine;
   assumption.
 Qed.
@@ -142,7 +142,7 @@ intros.
 unfold derive_lang.
 unfold derive_lang_a.
 unfold "{<->}".
-unfold "`elem`".
+unfold "\in".
 intros.
 listerine.
 easy.
@@ -151,8 +151,8 @@ Qed.
 (* Alternative inductive predicate for derive_lang *)
 Inductive derive_lang_a' (R: lang) (a: alphabet) (t: str): Prop :=
   | mk_derive_lang:
-    (a :: t) `elem` R ->
-    t `elem` (derive_lang_a' R a)
+    (a :: t) \in R ->
+    t \in (derive_lang_a' R a)
   .
 
 Theorem derive_lang_a_star_a:
@@ -441,24 +441,24 @@ Qed.
 (*
   Next consider:
   derive_lang_a (R: lang) (a: alphabet) (t: str): Prop :=
-  (a :: t) `elem` R.
+  (a :: t) \in R.
   derive_lang_a (concat_lang P Q)
   Let:
   P = delta_def(P) or P_0
   where delta_def(P_0) = emptyset
   Then:
   derive_lang_a (concat_lang P Q) a
-    {<->} {s | (a :: s) `elem` (concat_lang P Q)}
-    {<->} {s | (a :: s) `elem` (concat_lang (or_lang {{delta_def(P)}} P_0) Q)}
-    {<->} {u | (a :: u) `elem` (concat_lang {{delta_def(P)}} Q)}
+    {<->} {s | (a :: s) \in (concat_lang P Q)}
+    {<->} {s | (a :: s) \in (concat_lang (or_lang {{delta_def(P)}} P_0) Q)}
+    {<->} {u | (a :: u) \in (concat_lang {{delta_def(P)}} Q)}
           \/
-          {v | (a :: v) `elem` (concat_lang P_0 Q)}
+          {v | (a :: v) \in (concat_lang P_0 Q)}
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
-          {v_1 ++ v_2 | (a :: v_1) `elem` P_0, v_2 `elem` Q}
+          {v_1 ++ v_2 | (a :: v_1) \in P_0, v_2 \in Q}
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
-          concat_lang ({v_1 | (a :: v_1) `elem` P_0}) Q
+          concat_lang ({v_1 | (a :: v_1) \in P_0}) Q
     {<->} concat_lang {{delta_def(P)}} (derive_lang_a Q a)
           \/
           concat_lang (derive_lang_a P_0 a) Q.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -25,14 +25,14 @@ Definition x11star := concat x1 (star x1).
 Definition exampleR := and xI111I (complement (or xI01 x11star)).
 
 Theorem notelem_emptyset: forall (s: str),
-  s `notelem` emptyset_lang.
+  s \notin emptyset_lang.
 Proof.
 intros.
 untie.
 Qed.
 
 Lemma test_elem_xI01_101:
-  ([A1] ++ [A0] ++ [A1]) `elem` {{xI01}}.
+  ([A1] ++ [A0] ++ [A1]) \in {{xI01}}.
 Proof.
 unfold xI01.
 destruct_concat_lang.
@@ -54,7 +54,7 @@ constructor.
 Qed.
 
 Lemma test_notelem_xI01_101_false:
-  ([A1] ++ [A0] ++ [A1]) `notelem` {{xI01}}  -> False.
+  ([A1] ++ [A0] ++ [A1]) \notin {{xI01}}  -> False.
 Proof.
 unfold not.
 intros.
@@ -64,14 +64,14 @@ Qed.
 
 Local Ltac elemt :=
   match goal with
-  | [ H : _ `elem` _ |- _ ] =>
+  | [ H : _ \in _ |- _ ] =>
     inversion H; clear H
-  | [ |- context [_ `notelem` _ ] ] =>
+  | [ |- context [_ \notin _ ] ] =>
     unfold not; intros
   end.
 
 Lemma test_notleme_xI01_empty:
-    [] `notelem` {{xI01}}.
+    [] \notin {{xI01}}.
 Proof.
 elemt.
 elemt.
@@ -82,7 +82,7 @@ elemt.
 Qed.
 
 Lemma test_notelem_xI01_10:
-  ([A1] ++ [A0]) `notelem` {{xI01}}.
+  ([A1] ++ [A0]) \notin {{xI01}}.
 Proof.
 elemt.
 elemt.
@@ -97,7 +97,7 @@ contradiction.
 Qed.
 
 Lemma test_notelem_xI01_1110:
-  ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{xI01}}.
+  ([A1] ++ [A1] ++ [A1] ++ [A0]) \notin {{xI01}}.
 Proof.
 elemt.
 elemt.
@@ -109,7 +109,7 @@ listerine.
 Qed.
 
 Lemma test_notelem_x11star_0:
-  [A0] `notelem` {{ x11star }}.
+  [A0] \notin {{ x11star }}.
 Proof.
 elemt.
 elemt.
@@ -124,7 +124,7 @@ elemt.
 Qed.
 
 Lemma test_notelem_starx1_0:
-  [A0] `notelem` {{star x1}}.
+  [A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
@@ -135,7 +135,7 @@ invs H.
 Qed.
 
 Lemma test_notelem_starx1_10:
-  [A1; A0] `notelem` {{star x1}}.
+  [A1; A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
@@ -148,7 +148,7 @@ invs H.
 Qed.
 
 Lemma test_notelem_starx1_110:
-  [A1; A1; A0] `notelem` {{star x1}}.
+  [A1; A1; A0] \notin {{star x1}}.
 Proof.
 untie.
 invs H.
@@ -159,7 +159,7 @@ assumption.
 Qed.
 
 Lemma test_notelem_x11star_1110:
-  ([A1] ++ [A1] ++ [A1] ++ [A0]) `notelem` {{x11star}}.
+  ([A1] ++ [A1] ++ [A1] ++ [A0]) \notin {{x11star}}.
 Proof.
 untie.
 invs H.
@@ -170,7 +170,7 @@ listerine; (try invs H1).
 Qed.
 
 Lemma test_elem_xI111I_1110:
-    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{xI111I}}.
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) \in {{xI111I}}.
 Proof.
 destruct_concat_lang.
 exists [].
@@ -204,7 +204,7 @@ split.
 Qed.
 
 Theorem test_exampleR_1110_elem:
-    ([A1] ++ [A1] ++ [A1] ++ [A0]) `elem` {{exampleR}}.
+    ([A1] ++ [A1] ++ [A1] ++ [A0]) \in {{exampleR}}.
 Proof.
 constructor.
 split.
@@ -238,7 +238,7 @@ split.
 Qed.
 
 Theorem test_exampleR_111_notelem:
-    [A1; A1; A1] `notelem` {{exampleR}}.
+    [A1; A1; A1] \notin {{exampleR}}.
 Proof.
 untie.
 invs H.

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -13,18 +13,18 @@ Definition str := list alphabet.
 (* A regular expression denotes a set of strings called a _language_. *)
 Definition lang := str -> Prop.
 Definition elem (l: lang) (s: str): Prop := l s.
-Notation "p `elem` P" := (elem P p) (at level 80).
-Notation "p `notelem` P" := (~ (elem P p)) (at level 80).
+Notation " p \in P " := (elem P p) (at level 20).
+Notation " p \notin P " := (not (elem P p)) (at level 20).
 
 Definition lang_if (s1 s2: lang): Prop :=
   forall (s: str),
-  s `elem` s1 -> s `elem` s2.
+  s \in s1 -> s \in s2.
 
 Notation "s1 {->} s2" := (lang_if s1 s2) (at level 80).
 
 Definition lang_iff (s1 s2: lang): Prop :=
   forall (s: str),
-  s `elem` s1 <-> s `elem` s2.
+  s \in s1 <-> s \in s2.
 
 Notation "s1 {<->} s2" := (lang_iff s1 s2) (at level 80).
 
@@ -71,7 +71,7 @@ Inductive symbol_lang (a: alphabet): lang :=
 *)
 Inductive nor_lang (P Q: lang): lang :=
   | mk_nor : forall s,
-    s `notelem` P /\ s `notelem` Q ->
+    s \notin P /\ s \notin Q ->
     nor_lang P Q s
   .
 
@@ -79,8 +79,8 @@ Inductive nor_lang (P Q: lang): lang :=
 Inductive concat_lang (P Q: lang): lang :=
   | mk_concat: forall (p q s: str),
     p ++ q = s ->
-    p `elem` P ->
-    q `elem` Q ->
+    p \in P ->
+    q \in Q ->
     concat_lang P Q s
   .
 
@@ -89,9 +89,9 @@ Inductive star_lang (R: lang): lang :=
   | mk_star_more : forall (s p q: str),
       p ++ q = s ->
       p <> [] ->
-      p `elem` R ->
-      q `elem` (star_lang R) ->
-      s `elem` star_lang R.
+      p \in R ->
+      q \in (star_lang R) ->
+      s \in star_lang R.
 
 (*
   Here we use a mix of Fixpoint and Inductive predicates to define the denotation of regular expressions.

--- a/src/Brzozowski/Setoid.v
+++ b/src/Brzozowski/Setoid.v
@@ -31,7 +31,7 @@ Theorem lang_iff_trans : forall A B C:lang, (A {<->} B) -> (B {<->} C) -> (A {<-
     intros.
     specialize H with s.
     specialize H0 with s.
-    unfold "`elem`" in *.
+    unfold "\in" in *.
     apply iff_trans with (A := A s) (B := B s); assumption.
   Qed.
 
@@ -41,7 +41,7 @@ Theorem lang_iff_sym : forall A B:lang, (A {<->} B) -> (B {<->} A).
     unfold "{<->}" in *.
     intros.
     specialize H with s.
-    unfold "`elem`" in *.
+    unfold "\in" in *.
     apply iff_sym.
     assumption.
   Qed.
@@ -64,7 +64,7 @@ Add Parametric Morphism: nor_lang
 Proof.
 intros.
 unfold "{<->}" in *.
-unfold "`elem`" in *.
+unfold "\in" in *.
 intros.
 specialize H with s.
 specialize H0 with s.
@@ -73,7 +73,7 @@ constructor;
   constructor;
   wreckit;
     untie;
-    unfold "`elem`" in *;
+    unfold "\in" in *;
     invs H1;
     wreckit.
 - apply L.
@@ -117,7 +117,7 @@ Qed.
 Lemma star_lang_morph_helper:
   forall (x y : lang) (s: str),
   (x {<->} y)
-  -> (s `elem` star_lang x -> s `elem` star_lang y).
+  -> (s \in star_lang x -> s \in star_lang y).
 Proof.
   intros.
   induction H0.
@@ -129,7 +129,7 @@ Qed.
 Theorem star_lang_morph':
   forall (x y : lang) (s: str),
   (x {<->} y)
-  -> (s `elem` star_lang x <-> s `elem` star_lang y).
+  -> (s \in star_lang x <-> s \in star_lang y).
 Proof.
   intros.
   split.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -61,7 +61,7 @@ Theorem not_lang_not_lang_is_lang: forall (r: regex),
 Proof.
 intros.
 split.
-- assert (s `elem` {{ r }} \/ s `notelem` {{ r }}).
+- assert (s \in {{ r }} \/ s \notin {{ r }}).
   admit. (* TODO: apply denotation_is_decidable *)
   intros.
   wreckit.
@@ -74,7 +74,7 @@ split.
     constructor.
     wreckit.
     assumption.
-- assert (s `elem` {{ r }} \/ s `notelem` {{ r }}).
+- assert (s \in {{ r }} \/ s \notin {{ r }}).
   admit. (* TODO: apply denotation_is_decidable *)
   intros.
   constructor.

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -39,9 +39,9 @@ Inductive star_lang (R: lang): lang :=
   | mk_star_more : forall (s p q: str),
       p ++ q = s ->
       p <> [] ->
-      p `elem` R ->
-      q `elem` (star_lang R) ->
-      s `elem` star_lang R.
+      p \in R ->
+      q \in (star_lang R) ->
+      s \in star_lang R.
 
 The other definitions are:
   - star_lang_ex_empty
@@ -63,7 +63,7 @@ Inductive star_lang_ex_empty (R: lang): lang :=
   | mk_star_zero_ex_empty : forall (s: str),
     s = [] -> star_lang_ex_empty R s
   | mk_star_more_ex_empty : forall (s: str),
-    s `elem` (concat_lang_ex R (star_lang_ex_empty R)) ->
+    s \in (concat_lang_ex R (star_lang_ex_empty R)) ->
     star_lang_ex_empty R s.
 
 (* star_lang_empty is a middle ground:
@@ -75,9 +75,9 @@ Inductive star_lang_empty (R: lang): lang :=
       s = [] -> star_lang_empty R s
   | mk_star_more_empty : forall (s p q: str),
       p ++ q = s ->
-      p `elem` R ->
-      q `elem` (star_lang_empty R) ->
-      s `elem` star_lang_empty R.
+      p \in R ->
+      q \in (star_lang_empty R) ->
+      s \in star_lang_empty R.
 
 (* concat_ex_prefix_not_empty_lang is a helper for star_lang_ex
    It uses existence to define concat and
@@ -90,8 +90,8 @@ Inductive concat_ex_prefix_not_empty_lang (P Q: lang): lang :=
       (a: alphabet)
       (q: str)
       (pqs: (a :: p) ++ q = s),
-      (a :: p) `elem` P /\
-      q `elem` Q
+      (a :: p) \in P /\
+      q \in Q
     ) ->
     concat_ex_prefix_not_empty_lang P Q s
 .
@@ -104,7 +104,7 @@ Inductive star_lang_ex (R: lang): lang :=
   | mk_star_zero_ex : forall (s: str),
       s = [] -> star_lang_ex R s
   | mk_star_more_ex : forall (s: str),
-      s `elem` (concat_ex_prefix_not_empty_lang R (star_lang_ex R)) ->
+      s \in (concat_ex_prefix_not_empty_lang R (star_lang_ex R)) ->
       star_lang_ex R s.
 
 (* The Propositions below shows how each of the 4 definitions are equivalent to star_lang. *)
@@ -139,8 +139,8 @@ Local Proposition star_lang_ex_ind_better:
    (forall s: str, (exists (p q: str),
                   p ++ q = s /\
                   p <> [] /\
-                  p `elem` R /\
-                  q `elem` star_lang_ex R /\
+                  p \in R /\
+                  q \in star_lang_ex R /\
                   P q) ->
               P s) ->
    (* conclusion *)
@@ -196,8 +196,8 @@ Local Proposition star_lang_ex_empty_ind_better:
    (* induction step *)
    (forall s: str, (exists (p q: str),
                   p ++ q = s /\
-                  p `elem` R /\
-                  q `elem` star_lang_ex_empty R /\
+                  p \in R /\
+                  q \in star_lang_ex_empty R /\
                   P q) ->
               P s) ->
    (* conclusion *)


### PR DESCRIPTION
Walter already tried to do this in https://github.com/awalterschulze/regex-reexamined-coq/pull/132 but had some problems.

This approach seems to work - I'm not sure why.