### PR TITLE
replace nor with or + not

### DIFF
--- a/src/Brzozowski/Decidable.v
+++ b/src/Brzozowski/Decidable.v
@@ -64,34 +64,37 @@ destruct s.
       invs H.
 Qed.
 
-Lemma denotation_nor_is_decidable (p q: regex) (s: str):
+Lemma denotation_or_is_decidable (p q: regex) (s: str):
   s \in {{ p }} \/ s \notin {{ p }} ->
   s \in {{ q }} \/ s \notin {{ q }} ->
-  s \in {{ nor p q }} \/ s \notin {{ nor p q }}.
+  s \in {{ or p q }} \/ s \notin {{ or p q }}.
 Proof.
 simpl.
 intros.
 wreckit.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  contradiction.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  contradiction.
-- right.
-  untie.
-  invs H.
-  wreckit.
-  contradiction.
 - left.
   constructor.
-  wreckit.
-  * assumption.
-  * assumption.
+  auto.
+- left.
+  constructor.
+  auto.
+- left.
+  constructor.
+  auto.
+- right.
+  untie.
+  invs H.
+  wreckit; contradiction.
+Qed.
+
+Lemma denotation_neg_is_decidable (p: regex) (s: str):
+  s \in {{ p }} \/ s \notin {{ p }} ->
+  s \in {{ neg p }} \/ s \notin {{ neg p }}.
+Proof.
+intros.
+wreckit.
+- right. simpl. untie. invs H. contradiction.
+- left. simpl. untie. constructor. assumption.
 Qed.
 
 (*
@@ -688,13 +691,14 @@ induction r.
 - apply denotation_emptyset_is_decidable.
 - apply denotation_lambda_is_decidable.
 - intros. apply denotation_symbol_is_decidable.
+- intros. apply denotation_or_is_decidable.
+  + specialize IHr1 with s. assumption.
+  + specialize IHr2 with s. assumption.
+- intros. apply denotation_neg_is_decidable.
+  specialize IHr with s. assumption.
 - intros. apply denotation_concat_is_decidable;
   unfold regex_is_decidable;
   assumption.
 - apply denotation_star_is_decidable.
   assumption.
-- intros.
-  specialize IHr1 with s.
-  specialize IHr2 with s.
-  apply denotation_nor_is_decidable; assumption.
 Qed.

--- a/src/Brzozowski/ExampleR.v
+++ b/src/Brzozowski/ExampleR.v
@@ -23,7 +23,7 @@ Definition x0 := symbol A0.
 Definition xI111I := concat I (concat x1 (concat x1 (concat x1 I))).
 Definition xI01 := concat I (concat x0 x1).
 Definition x11star := concat x1 (star x1).
-Definition exampleR := and xI111I (complement (or xI01 x11star)).
+Definition exampleR := and xI111I (neg (or xI01 x11star)).
 
 Theorem notelem_emptyset: forall (s: str),
   s \notin emptyset_lang.
@@ -208,33 +208,21 @@ Theorem test_exampleR_1110_elem:
     ([A1] ++ [A1] ++ [A1] ++ [A0]) \in {{exampleR}}.
 Proof.
 constructor.
-split.
-- untie.
-  invs H.
-  wreckit.
-  apply L.
+untie.
+invs H.
+destruct H0.
+- invs H.
+  apply H0.
   apply test_elem_xI111I_1110.
-- untie.
-  invs H.
-  wreckit.
-  apply L.
-  clear R.
-  clear L.
+- invs H.
+  apply H0.
   constructor.
-  wreckit.
   untie.
   invs H.
-  wreckit.
-  apply L.
-  clear L.
-  clear R.
-  constructor.
-  wreckit.
-  + untie.
-    apply test_notelem_xI01_1110.
+  destruct H1.
+  + apply  test_notelem_xI01_1110.
     assumption.
-  + untie.
-    apply test_notelem_x11star_1110.
+  + apply test_notelem_x11star_1110.
     assumption.
 Qed.
 
@@ -243,35 +231,30 @@ Theorem test_exampleR_111_notelem:
 Proof.
 untie.
 invs H.
-wreckit.
-apply R.
+apply H0.
 constructor.
-wreckit.
+right.
+constructor.
 untie.
 invs H.
-wreckit.
-apply L0.
+apply H1.
 constructor.
-wreckit.
-untie.
-invs H.
-wreckit.
-apply R1.
+right.
+unfold x11star.
 destruct_concat_lang.
 exists [A1].
 exists [A1; A1].
-exists eq_refl.
-wreckit.
+assert ([A1] ++ [A1; A1] = [A1; A1; A1]). listerine; reflexivity.
+exists H.
+split.
 - constructor.
 - apply mk_star_more with (p := [A1]) (q := [A1]).
   + listerine. reflexivity.
   + listerine.
-  + fold (denote_regex x1).
-    constructor.
-  + fold (denote_regex x1).
-    apply mk_star_more with (p := [A1]) (q := []).
-    * now listerine.
+  + constructor.
+  + apply mk_star_more with (p := [A1]) (q := []).
+    * listerine. reflexivity.
     * listerine.
     * constructor.
     * constructor.
-Qed.
+Qed.    

--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -67,12 +67,18 @@ Inductive symbol_lang (a: alphabet): lang :=
 (*
     *Boolean function*. We shall denote any Boolean function of $P$ and $Q$ by $f(P, Q)$.
     Of course, all the laws of Boolean algebra apply.
-    `nor` is used to emulate `f`, since nor can be used to emulate all boolean functions.
+    `neg` and `or` are used to emulate `f`, since they can be used to emulate all boolean functions.
 *)
-Inductive nor_lang (P Q: lang): lang :=
-  | mk_nor : forall s,
-    s \notin P /\ s \notin Q ->
-    nor_lang P Q s
+Inductive or_lang (P Q: lang): lang :=
+  | mk_or : forall s,
+    s \in P \/  s \in Q ->
+    or_lang P Q s
+  .
+
+Inductive neg_lang (P: lang): lang :=
+  | mk_neg : forall s,
+    s \notin P ->
+    neg_lang P s
   .
 
 (* Concatenation*. $(P.Q) = \{ s | s = p.q; p \in P, q \in Q \}$. *)
@@ -102,9 +108,10 @@ Fixpoint denote_regex (r: regex): lang :=
   | emptyset => emptyset_lang
   | lambda => lambda_lang
   | symbol y => symbol_lang y
+  | or r1 r2 => or_lang {{r1}} {{r2}}
+  | neg r1 => neg_lang {{r1}}
   | concat r1 r2 => concat_lang {{r1}} {{r2}}
   | star r1 => star_lang {{r1}}
-  | nor r1 r2 => nor_lang {{r1}} {{r2}}
   end
 where "{{ r }}" := (denote_regex r).
 

--- a/src/Brzozowski/LogicOp.v
+++ b/src/Brzozowski/LogicOp.v
@@ -12,38 +12,32 @@ Require Import Brzozowski.Setoid.
    which is one of the selling points of Brzozowski's derivatives for regular expressions.
 *)
 
-Definition complement (r: regex) : regex :=
-  nor r r.
+Definition nor (r s: regex) : regex :=
+  neg (or r s).
 
 Definition and (r s: regex) : regex :=
-  nor (nor r r) (nor s s).
-
-Definition or (r s: regex) : regex :=
-  nor (nor r s) (nor r s).
+  neg (or (neg r) (neg s)).
 
 Definition xor (r s: regex) : regex :=
-  or (and r (complement s)) (and (complement r) s).
+  or (and r (neg s)) (and (neg r) s).
 
 (* I matches all strings *)
 Definition I: regex :=
-  complement (emptyset).
+  neg (emptyset).
 
-Definition not_lang (R: lang) : lang :=
-  nor_lang R R.
+Definition nor_lang (P Q: lang) : lang :=
+  neg_lang (or_lang P Q).
 
 Definition and_lang (P Q: lang) : lang :=
-  nor_lang (nor_lang P P) (nor_lang Q Q).
-
-Definition or_lang (P Q: lang) : lang :=
-  nor_lang (nor_lang P Q) (nor_lang P Q).
+  neg_lang (or_lang (neg_lang P) (neg_lang Q)).
 
 Lemma denote_regex_or_step:
   forall (p q: regex),
-  {{or p q}} {<->} or_lang {{p}} {{q}}.
+  {{nor p q}} {<->} nor_lang {{p}} {{q}}.
 Proof.
   intros.
   cbn.
-  unfold or_lang.
+  unfold nor_lang.
   reflexivity.
 Qed.
 
@@ -57,27 +51,17 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma denote_regex_complement_step:
-  forall (r: regex),
-  {{complement r}} {<->} not_lang {{r}}.
-Proof.
-  intros.
-  cbn.
-  unfold not_lang.
-  reflexivity.
-Qed.
-
-Add Parametric Morphism: or_lang
-  with signature lang_iff ==> lang_iff ==> lang_iff as or_lang_morph.
+Add Parametric Morphism: nor_lang
+  with signature lang_iff ==> lang_iff ==> lang_iff as nor_lang_morph.
 Proof.
 intros.
-unfold or_lang.
+unfold nor_lang.
 rewrite H.
 rewrite H0.
 reflexivity.
 Qed.
 
-Existing Instance or_lang_morph_Proper.
+Existing Instance nor_lang_morph_Proper.
 
 Add Parametric Morphism: and_lang
   with signature lang_iff ==> lang_iff ==> lang_iff as and_lang_morph.
@@ -91,64 +75,18 @@ Qed.
 
 Existing Instance and_lang_morph_Proper.
 
-Add Parametric Morphism: not_lang
-  with signature lang_iff ==> lang_iff as not_lang_morph.
-Proof.
-intros.
-unfold not_lang.
-rewrite H.
-reflexivity.
-Qed.
-
-Existing Instance not_lang_morph_Proper.
-
-Theorem or_denotes_or_lang:
+Theorem nor_denotes_nor_lang:
   forall (p q: regex),
-  {{or p q}} {<->} or_lang {{p}} {{q}}.
+  {{nor p q}} {<->} nor_lang {{p}} {{q}}.
 Proof.
 intros.
 split.
 - intros.
   cbn in *.
-  unfold or_lang.
+  unfold nor_lang.
   assumption.
 - intros.
   cbn in *.
-  unfold or_lang in H.
+  unfold nor_lang in H.
   assumption.
-Qed.
-
-Theorem or_lang_is_disj:
-  forall (p q: regex) (s: str),
-  s \in or_lang {{p}} {{q}} <-> s \in {{p}} \/ s \in {{q}}.
-Proof.
-intros.
-split.
-- intros.
-  destruct H.
-  destruct H.
-  clear H0.
-  unfold elem in H.
-  destruct (denotation_is_decidable p s);
-  destruct (denotation_is_decidable q s);
-  auto.
-  + exfalso. apply H. constructor. split; assumption.
-- intros.
-  constructor.
-  split; destruct H; unfold elem; untie;
-  destruct H0; wreckit; contradiction.
-Qed.
-
-Theorem or_is_disj:
-  forall (p q: regex) (s: str),
-  s \in {{ or p q }} <-> s \in {{p}} \/ s \in {{q}}.
-Proof.
-intros.
-specialize or_denotes_or_lang with (p := p) (q := q).
-intros or_is_or_lang.
-unfold lang_iff in or_is_or_lang.
-specialize or_is_or_lang with (s := s).
-rewrite or_is_or_lang.
-rewrite or_lang_is_disj.
-reflexivity.
 Qed.

--- a/src/Brzozowski/Regex.v
+++ b/src/Brzozowski/Regex.v
@@ -7,17 +7,16 @@ Inductive regex :=
   | lambda : regex
   (* symbol matches only strings of length 1 containing the exact alphabet symbol *)
   | symbol : alphabet -> regex
+  (* or takes the union of two regular expressions *)
+  | or : regex -> regex -> regex
+  (* 
+    neg or negation is the `not` or `complement` operator, that we use to avoid confusion with
+    the `not` function for properties.s
+    Using the two logical operators `or` and `neg` we can represent all other logical operators 
+  *)
+  | neg : regex -> regex
   (* concat is used to build of regular expressions that can match longer strings *)
   | concat : regex -> regex -> regex
   (* zero or more, as you are familiar with from regular expressions *)
   | star : regex -> regex
-  (* `nor` is a boolean operator, here is the truth table
-     P | Q | P `nor` Q
-     -----------------
-     T | T | F
-     T | F | F
-     F | T | F
-     F | F | T
-  *)
-  | nor : regex -> regex -> regex
   .

--- a/src/Brzozowski/Setoid.v
+++ b/src/Brzozowski/Setoid.v
@@ -59,8 +59,8 @@ Existing Instance lang_setoid.
    nor_lang_morph allows rewrite to work inside nor_lang parameters
    see Example NorLangMorphSetoidRewrite
 *)
-Add Parametric Morphism: nor_lang
-  with signature lang_iff ==> lang_iff ==> lang_iff as nor_lang_morph.
+Add Parametric Morphism: or_lang
+  with signature lang_iff ==> lang_iff ==> lang_iff as or_lang_morph.
 Proof.
 intros.
 unfold "{<->}" in *.
@@ -68,29 +68,44 @@ unfold "\in" in *.
 intros.
 specialize H with s.
 specialize H0 with s.
-constructor;
-  intros;
-  constructor;
-  wreckit;
-    untie;
-    unfold "\in" in *;
-    invs H1;
-    wreckit.
-- apply L.
-  apply H.
+constructor.
+- intros.
+  constructor.
+  invs H1.
+  rewrite <- H.
+  rewrite <- H0.
   assumption.
-- apply R.
-  apply H0.
-  assumption.
-- apply L.
-  apply H.
-  assumption.
-- apply R.
-  apply H0.
+- intros.
+  constructor.
+  invs H1.
+  rewrite H.
+  rewrite H0.
   assumption.
 Qed.
 
-Existing Instance nor_lang_morph_Proper.
+Existing Instance or_lang_morph_Proper.
+
+Add Parametric Morphism: neg_lang
+  with signature lang_iff ==> lang_iff as neg_lang_morph.
+Proof.
+intros.
+unfold "{<->}" in *.
+intros.
+specialize H with s.
+split.
+- intros.
+  constructor.
+  invs H0.
+  rewrite <- H.
+  assumption.
+- intros.
+  constructor.
+  invs H0.
+  rewrite H.
+  assumption.
+Qed.
+
+Existing Instance neg_lang_morph_Proper.
 
 (*
    concat_lang_morph allows rewrite to work inside concat_lang parameters
@@ -180,22 +195,22 @@ reflexivity.
 Qed.
 
 (*
-  The implementation of not_lang_morph allows the use of rewrite inside nor_lang parameters.
+  The implementation of or_lang_morph allows the use of rewrite inside or_lang parameters.
 *)
-Example NorLangMorphSetoidRewrite: forall (r s: lang),
-  nor_lang (concat_lang emptyset_lang r) s
+Example OrLangMorphSetoidRewrite: forall (r s: lang),
+  or_lang (concat_lang emptyset_lang r) s
   {<->}
-  nor_lang emptyset_lang s.
+  or_lang emptyset_lang s.
 Proof.
 intros.
 rewrite lemma_for_setoid_example_concat_lang_emptyset_l_is_emptyset.
 reflexivity.
 Qed.
 
-Example StarLangNorLangMorphSetoidRewrite: forall (r s: lang),
-  star_lang (nor_lang (concat_lang emptyset_lang r) s)
+Example StarLangOrLangMorphSetoidRewrite: forall (r s: lang),
+  star_lang (or_lang (concat_lang emptyset_lang r) s)
   {<->}
-  star_lang (nor_lang emptyset_lang s).
+  star_lang (or_lang emptyset_lang s).
 Proof.
 intros.
 rewrite lemma_for_setoid_example_concat_lang_emptyset_l_is_emptyset.

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -52,40 +52,17 @@ r&s = s&r
 r** = r*
 λ* = λ
 ∅* = λ
-not_lang_not_lang_is_lang: ~~r = r
+neg_lang_neg_lang_is_lang: ~~r = r
 *)
 
-Theorem not_lang_not_lang_is_lang: forall (r: regex),
-  not_lang (not_lang {{r}})
+Theorem neg_lang_neg_lang_is_lang: forall (r: regex),
+  neg_lang (neg_lang {{r}})
   {<->}
   {{r}}.
 Proof.
-intros.
-split.
-- assert (s \in {{ r }} \/ s \notin {{ r }}).
-  admit. (* TODO: apply denotation_is_decidable *)
-  intros.
-  wreckit.
-  + assumption.
-  + invs H0.
-    wreckit.
-    unfold not in L.
-    exfalso.
-    apply L.
-    constructor.
-    wreckit.
-    assumption.
-- assert (s \in {{ r }} \/ s \notin {{ r }}).
-  admit. (* TODO: apply denotation_is_decidable *)
-  intros.
-  constructor.
-  wreckit.
-  + unfold not.
-    intros.
-    invs H.
-    wreckit.
-    contradiction.
-  + contradiction.
+(* TODO: Good First Issue
+   You will need to use denotation_is_decidable.
+*)
 Abort.
 
 Theorem concat_lang_emptyset_l_is_emptyset: forall (r: lang),


### PR DESCRIPTION
Review, but **DO NOT MERGE** There is a stack of pull requests that depends on this one.  Let me worry about doing it in the right order.

Fixes #145 

I replaced `nor` with `or` and `not`

The reasoning:

It is possible to represent all logic operators, using only two logic operators.
`or` is the natural one we want, since it is used to define `concat` and `concat` is used again by `star`.
We only need to add the `not` operator, which then allows us to represent `nor`

```
P | Q | P nor Q
-----------------
T | T | F
T | F | F
F | T | F
F | F | T

P | Q | not (P or Q)
-----------------
T | T | F
T | F | F
F | T | F
F | F | T
```

, which allows us to represent all logic operators, for example `and`

```
P | Q | P and Q
-----------------
T | T | T
T | F | F
F | T | F
F | F | F

P | Q | not ((not P) or (not Q))
-----------------
T | T | T
T | F | F
F | T | F
F | F | F
```

I think we should replace `nor` with `not` and `or`.  It is still a minimal extension, but allows us to more naturally work for `concat` and `star`, which are typically the hardest proofs we have to do.