### PR TITLE
proof and is conj and some more simplification rules

### DIFF
--- a/src/Brzozowski/LogicOp.v
+++ b/src/Brzozowski/LogicOp.v
@@ -1,5 +1,6 @@
 Require Import Coq.Setoids.Setoid.
 
+Require Import CoqStock.Invs.
 Require Import CoqStock.Untie.
 Require Import CoqStock.WreckIt.
 
@@ -49,6 +50,58 @@ Proof.
   cbn.
   unfold and_lang.
   reflexivity.
+Qed.
+
+Theorem and_lang_is_conj:
+  forall (p q: regex) (s: str),
+  s \in and_lang {{p}} {{q}} <-> s \in {{p}} /\ s \in {{q}}.
+Proof.
+intros.
+unfold and_lang.
+specialize denotation_is_decidable with (r := p) (s := s) as Dp.
+specialize denotation_is_decidable with (r := q) (s := s) as Dq.
+destruct Dp, Dq; split; intros; split; try assumption.
+- untie. 
+  invs H2.
+  invs H3; invs H2; contradiction. 
+- invs H1.
+  exfalso.
+  apply H2.
+  constructor.
+  right.
+  constructor.
+  assumption.
+- untie.
+  invs H2.
+  invs H1.
+  contradiction.
+- invs H1.
+  exfalso.
+  apply H2.
+  constructor.
+  left.
+  constructor.
+  assumption.
+- untie.
+  invs H2.
+  invs H1.
+  contradiction.
+- invs H1.
+  exfalso.
+  apply H2.
+  constructor.
+  left.
+  constructor.
+  assumption.
+- invs H1.
+  exfalso.
+  apply H2.
+  constructor.
+  left.
+  constructor.
+  assumption.
+- invs H1.
+  contradiction.
 Qed.
 
 Add Parametric Morphism: nor_lang

--- a/src/Brzozowski/Simplify.v
+++ b/src/Brzozowski/Simplify.v
@@ -11,6 +11,7 @@ Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.ConcatLang.
+Require Import Brzozowski.Decidable.
 Require Import Brzozowski.Language.
 Require Import Brzozowski.LogicOp.
 Require Import Brzozowski.Regex.
@@ -60,10 +61,27 @@ Theorem neg_lang_neg_lang_is_lang: forall (r: regex),
   {<->}
   {{r}}.
 Proof.
-(* TODO: Good First Issue
-   You will need to use denotation_is_decidable.
-*)
-Abort.
+unfold lang_iff.
+intros.
+specialize denotation_is_decidable with (s := s) (r := r) as D.
+destruct D.
+- split.
+  + auto.
+  + intros.
+    constructor.
+    untie.
+    invs H1.
+    contradiction.
+- split.
+  + intros.
+    invs H0.
+    exfalso.
+    apply H1.
+    constructor.
+    assumption.
+  + intros.
+    contradiction.
+Qed.
 
 Theorem concat_lang_emptyset_l_is_emptyset: forall (r: lang),
   concat_lang emptyset_lang r
@@ -134,4 +152,40 @@ split.
   split.
   + assumption.
   + constructor.
+Qed.
+
+Theorem or_lang_emptyset_r_is_l: forall (r: lang),
+  or_lang r emptyset_lang
+  {<->}
+  r.
+Proof.
+intros.
+split.
+- intros.
+  invs H.
+  destruct H0.
+  + assumption.
+  + invs H.
+- intros.
+  constructor.
+  left.
+  assumption.
+Qed.
+
+Theorem or_lang_emptyset_l_is_r: forall (r: lang),
+  or_lang emptyset_lang r
+  {<->}
+  r.
+Proof.
+intros.
+split.
+- intros.
+  invs H.
+  destruct H0.
+  + invs H.
+  + assumption.
+- intros.
+  constructor.
+  right.
+  assumption.
 Qed.


### PR DESCRIPTION
Review, but **DO NOT MERGE** This relies on the #152 merging first, so I will make sure it merges in the right order.

This proves that the and operator is conjunction and negation of negation cancels out and some other simplification rules.