### PR TITLE
change definition of and to be property based

### DIFF
--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -114,4 +114,3 @@ Fixpoint denote_regex (r: regex): lang :=
   | star r1 => star_lang {{r1}}
   end
 where "{{ r }}" := (denote_regex r).
-

--- a/src/Brzozowski/Ring.v
+++ b/src/Brzozowski/Ring.v
@@ -12,6 +12,7 @@ Require Import CoqStock.WreckIt.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.Language.
+Require Import Brzozowski.LogicOp.
 Require Import Brzozowski.Regex.
 Require Import Brzozowski.Setoid.
 Require Import Brzozowski.Simplify.
@@ -20,13 +21,6 @@ Require Import Brzozowski.Simplify.
    Some are theorems that need to be proven or simply applied from Simplify.v
    Other parts are uncommentable once the theorems are proven.
 *)
-
-(* TODO: Move to LogicOp.v and replace and_lang *)
-Inductive and_lang (P Q: lang): lang :=
-  | mk_and : forall s,
-    s \in P /\ s \in Q ->
-    and_lang P Q s
-  .
 
 Theorem or_lang_emptyset_l:
   forall n : lang, or_lang emptyset_lang n {<->} n.
@@ -94,9 +88,8 @@ Lemma Eq_lang_s_ext: sring_eq_ext or_lang and_lang lang_iff.
 Proof.
 constructor.
 - exact or_lang_morph_Proper.
-(* TODO: Good First Issue *)
-(* - exact and_lang_morph_Proper. *)
-Abort.
+- exact and_lang_morph_Proper.
+Qed.
 
 (* TODO: Good First Issue *)
 (* Add Ring lang_semi_ring: lang_semi_ring


### PR DESCRIPTION
Review, but **DO NOT MERGE** This requires https://github.com/awalterschulze/regex-reexamined-coq/pull/158 to merge this. Let me worry about doing it in the right order.

Fixes https://github.com/awalterschulze/regex-reexamined-coq/issues/154

and_lang is redefined as P /\ Q and not defined in terms of or_lang
nor_lang is redefined as `s \notin P /\ s \notin Q` and not defined in terms of or_lang