### PR TITLE
Add Parametric Morphism: elem_morph

### DIFF
--- a/src/Brzozowski/Language.v
+++ b/src/Brzozowski/Language.v
@@ -12,9 +12,9 @@ Require Import Brzozowski.Regex.
 Definition str := list alphabet.
 (* A regular expression denotes a set of strings called a _language_. *)
 Definition lang := str -> Prop.
-Definition elem (l: lang) (s: str): Prop := l s.
-Notation " p \in P " := (elem P p) (at level 20).
-Notation " p \notin P " := (not (elem P p)) (at level 20).
+Definition elem (s: str) (l: lang): Prop := l s.
+Notation " p \in P " := (elem p P) (at level 20).
+Notation " p \notin P " := (not (elem p P)) (at level 20).
 
 Definition lang_if (s1 s2: lang): Prop :=
   forall (s: str),

--- a/src/Brzozowski/Setoid.v
+++ b/src/Brzozowski/Setoid.v
@@ -107,6 +107,29 @@ Qed.
 
 Existing Instance neg_lang_morph_Proper.
 
+Add Parametric Morphism {s}: (elem s)
+  with signature lang_iff ==> iff
+  as elem_morph.
+Proof.
+intros.
+unfold elem.
+unfold "{<->}" in H.
+specialize H with (s := s).
+unfold "\in" in H.
+assumption.
+Qed.
+
+Example example_rewriting_using_lang_iff_in_iff:
+  forall (p q: regex)
+  (pq: {{p}} {<->} {{q}}),
+  forall s: str,
+  s \in {{q}} <-> s \in {{p}}.
+Proof.
+intros.
+rewrite pq.
+reflexivity.
+Qed.
+
 (*
    concat_lang_morph allows rewrite to work inside concat_lang parameters
 *)

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -167,26 +167,26 @@ Qed.
 Proposition star_lang_ex_equivalent (R: lang):
     star_lang R {<->} star_lang_ex R.
 Proof.
-  split.
-  - intro Hmatch.
-    induction Hmatch.
-    + subst. now constructor.
-    + eapply (mk_star_more_ex R s); try (exact H).
-      constructor.
-      destruct p.
-      * contradiction.
-      * exists p.
-        exists a.
-        exists q.
-        exists H.
-        split; assumption.
-  - intro Hmatch.
-    apply (star_lang_ex_ind_better R).
-    + now constructor.
-    + intros.
-      destruct H as [p [q [Hconcat [ Hnon_empty [ Hp_match [Hq_match IH]]]]]].
-      constructor 2 with (p := p) (q := q); assumption.
-    + assumption.
+split.
+- intro Hmatch.
+  induction Hmatch.
+  + subst. now constructor.
+  + eapply (mk_star_more_ex R s); try (exact H).
+    constructor.
+    destruct p.
+    * contradiction.
+    * exists p.
+      exists a.
+      exists q.
+      exists H.
+      split; assumption.
+- intro Hmatch.
+  apply (star_lang_ex_ind_better R (star_lang R)).
+  + now constructor.
+  + intros.
+    destruct H as [p [q [Hconcat [ Hnon_empty [ Hp_match [Hq_match IH]]]]]].
+    constructor 2 with (p := p) (q := q); assumption.
+  + assumption.
 Qed.
 
 Local Proposition star_lang_ex_empty_ind_better:
@@ -236,7 +236,7 @@ Proof.
         exists H.
         split; assumption.
   - intro Hmatch.
-    apply (star_lang_ex_empty_ind_better R).
+    apply (star_lang_ex_empty_ind_better R (star_lang R)).
     + now constructor.
     + intros.
       destruct H as [p [q [Hconcat [ Hp_match [Hq_match IH]]]]].


### PR DESCRIPTION
We added another parametric morphism to our setoid, which allows us to reuse rewrite rules that are in `lang_iff` and apply them to `iff` with `\in`, which was frustratingly not possible before:
```
Add Parametric Morphism {s}: (elem s)
  with signature lang_iff ==> iff
  as elem_morph.
```

For example:
```
  forall (p q: regex)
  (pq: {{p}} {<->} {{q}}),
  forall s: str,
  s \in {{q}} <-> s \in {{p}}.
```

This should help to simplify the commutes_concat_a proof going forward.
