### PR TITLE
star commutes and thus derive commutes

### DIFF
--- a/src/Brzozowski/Setoid.v
+++ b/src/Brzozowski/Setoid.v
@@ -239,6 +239,39 @@ rewrite pq.
 reflexivity.
 Qed.
 
+Example example_rewriting_using_lang_iff_in_iff':
+  forall (P Q: lang)
+  (pq: P {<->} Q),
+  forall s: str,
+  s \in Q <-> s \in P.
+Proof.
+intros.
+rewrite pq.
+reflexivity.
+Qed.
+
+Example example_rewriting_using_lang_iff_in_iff'':
+  forall (P Q: lang)
+  (pq: P {<->} Q),
+  forall s: str,
+  s \in neg_lang Q <-> s \in neg_lang P.
+Proof.
+intros.
+rewrite pq.
+reflexivity.
+Qed.
+
+Example example_rewriting_using_lang_iff_in_iff''':
+  forall (R: lang)
+  (nnr: R {<->} neg_lang (neg_lang R)),
+  forall s: str,
+  s \in neg_lang R <-> s \in neg_lang (neg_lang (neg_lang R)).
+Proof.
+intros.
+rewrite <- nnr.
+reflexivity.
+Qed.
+
 (* Allow derive_langs expressions to also be rewritten using lang_iff expressions: *)
 
 Add Parametric Morphism {s: str}: (derive_langs s)

--- a/src/Brzozowski/StarLang.v
+++ b/src/Brzozowski/StarLang.v
@@ -1,9 +1,11 @@
+Require Import CoqStock.Invs.
 Require Import CoqStock.List.
 Require Import CoqStock.Listerine.
 
 Require Import Brzozowski.Alphabet.
 Require Import Brzozowski.ConcatLang.
 Require Import Brzozowski.Language.
+Require Import Brzozowski.Setoid.
 
 (*
 This module shows off different possible definitions of star_lang and how they are all equivalent
@@ -245,4 +247,43 @@ Proof.
       * constructor 2 with (p := (a :: p)) (q := q); try assumption.
         listerine.
     + assumption.
+Qed.
+
+Proposition decompose_star_lang (R: lang):
+  forall (s: str),
+    s \in star_lang R
+  <->
+  (
+    s = []
+  \/
+    (exists
+      (p: str)
+      (a: alphabet)
+      (q: str)
+      (splits: (a :: p) ++ q = s),
+      (a :: p) \in R
+    /\
+      q \in (star_lang R)
+    )
+  ).
+Proof.
+intros.
+rewrite star_lang_ex_equivalent.
+split; intros.
+- invs H.
+  + auto.
+  + right.
+    invs H0.
+    destruct H as [p [a [q [splits [inr instarr]]]]].
+    exists p, a, q, splits.
+    rewrite <- star_lang_ex_equivalent in instarr.
+    auto.
+- invs H.
+  + constructor. reflexivity.
+  + destruct H0 as [p [a [q [splits [inr instarr]]]]].
+    apply mk_star_more_ex.
+    constructor.
+    exists p, a, q, splits.
+    rewrite star_lang_ex_equivalent in instarr.
+    auto.
 Qed.


### PR DESCRIPTION
Finally it is done :D

This follows after proving concat commutes: https://github.com/awalterschulze/regex-reexamined-coq/pull/170

Proving star commutes was simply a matter of destructing with the non empty condition to avoid recursion that we have setup weeks ago.