### PR TITLE
cofixpoint derive tree

### DIFF
--- a/_CoqProject
+++ b/_CoqProject
@@ -37,6 +37,7 @@ src/Brzozowski/SplitEmptyStr.v
 src/Brzozowski/StarLang.v
 
 src/Coinduction/Bisimilar.v
+src/Coinduction/DeriveTree.v
 src/Coinduction/Setoid.v
 src/Coinduction/Simplify.v
 src/Coinduction/Trace.v

--- a/src/Coinduction/DeriveTree.v
+++ b/src/Coinduction/DeriveTree.v
@@ -1,0 +1,13 @@
+Require Import Brzozowski.Alphabet.
+Require Import Brzozowski.Derive.
+Require Import Brzozowski.Language.
+Require Import Brzozowski.Regex.
+
+CoInductive DeriveTree: Type :=
+  | mk_derive: lang -> (alphabet -> DeriveTree) -> DeriveTree.
+
+CoFixpoint build_regex_tree (r: regex): DeriveTree :=
+  mk_derive {{r}} (fun a => (build_regex_tree (derive_def r a))).
+
+CoFixpoint build_lang_tree (l: lang): DeriveTree :=
+  mk_derive l (fun a => (build_lang_tree (derive_lang a l))).


### PR DESCRIPTION
@Nielius came up with a CoInductive DeriveTree
It seems to cater for both lang and regex.

The idea is that this might be a better CoInductive type to use in conjunction with bisimilar.