### PR TITLE
tactic state can now handle hypothesis and terms

### DIFF
--- a/src/CoqStock/TacticState.v
+++ b/src/CoqStock/TacticState.v
@@ -3,29 +3,49 @@ TacticState is a tactic helper.
 It is used to avoid infinitely loops in your tactic
 by marking that a hypothesis has already been visited by your tactic.
 The API features 3 tactics:
-  - add_state: adds a state to the hypothesis as `H -> True`
+  - add_state: adds a state to the hypothesis as `mk_state (type of H) H`
   - has_state: fails if the state has not been added yet
   - clear_states: removes all states from the hypothesis
 *)
 
-Ltac add_state H :=
-  let T := type of H in
-  let S := fresh "state_" H in
-    assert (T -> True) as S by constructor.
+Inductive state (T: Type) (x: T): Prop :=
+  | mk_state: state T x.
 
-Ltac has_state H :=
+Ltac is_hyp H :=
   let T := type of H in
+  match goal with
+  | [ HName: T |- _ ] => idtac
+  | _ => fail
+  end.
+
+Ltac add_state E :=
+  tryif is_hyp E
+  then
+    let T := type of E in
+    pose (mk_state _ T)
+  else
+    pose (mk_state _ E).
+
+Ltac has_state E :=
+  tryif is_hyp E
+  then
+    let T := type of E in
     match goal with
-    | [ _: T -> True |- _ ] => idtac
-    | _ => fail "State doesn't contain the hypothesis:" T
-    end .
+    | [ S : state _ T |- _ ] => idtac
+    | _ => fail "State doesn't contain hypothesis:" E
+    end
+  else
+    match goal with
+    | [ S : state _ E |- _ ] => idtac
+    | _ => fail "State doesn't contain:" E
+    end.
 
 Ltac clear_states :=
-  repeat (
-    match goal with
-    | [H : _ -> True |- _] => clear H
-    end
-  ).
+repeat (
+  match goal with
+  | [H : state _ _ |- _] => clear H
+  end
+).
 
 Example example_state_api:
   forall (P Q : Prop),
@@ -39,4 +59,42 @@ Proof.
   Fail (has_state H).
   destruct H.
   assumption.
+Qed.
+
+Theorem example_state_api_2: 1 = 1.
+Proof.
+  add_state False.
+  add_state 2.
+  add_state (3 = 2).
+  assert True by constructor.
+  add_state nat.
+  has_state 2.
+  Fail has_state 3.
+  has_state nat.
+  Fail has_state Set.
+  add_state Set.
+  has_state Set.
+  clear_states.
+  Fail has_state 2.
+  reflexivity.
+Qed.
+
+(* This example resulted in endless loop in previous version of wreck_one *)
+Example example_one_is_one:
+  forall (x: nat), x = 1 -> 1 = 1.
+Proof.
+intros.
+inversion H as [H0].
+add_state H.
+(* This failed before.
+   We now use Tactic Notation to detect the type of expression
+   and call the appropriate add_state and has_state
+*)
+has_state H0.
+inversion H0 as [H1].
+add_state H1.
+inversion s.
+has_state H.
+Fail has_state nat.
+reflexivity.
 Qed.

--- a/src/CoqStock/WreckIt.v
+++ b/src/CoqStock/WreckIt.v
@@ -437,6 +437,14 @@ intros.
 wreckit; reflexivity.
 Qed.
 
+(* This example resulted in endless loop in previous version of wreck_one *)
+Example example_one_is_one:
+  forall (x: nat), x = 1 -> 1 = 1.
+Proof.
+intros.
+wreckit; auto.
+Qed.
+
 Example example_wreckit_disj: forall (x: nat) (e: exists (y: nat), (x = S y \/ S y = x) /\ y = O),
   x = S O \/ S O = x.
 Proof.


### PR DESCRIPTION
This builds on work done in pair programming session with @Nielius and @paulcadman 

This introduces
```
Inductive state (T: Type) (x: T): Prop :=
  | mk_state: state T x.
```

to replace
```
-> True
```

Before the state API was only able to handle hypothesis, but now it can handle expressions too.